### PR TITLE
feat: Maven Central 배포 지원

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: '**/build/reports/tests/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,28 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: testdb
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4
@@ -31,8 +16,8 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -48,4 +33,4 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: '**/build/reports/tests/'
+          path: "**/build/reports/tests/"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0)'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and verify
+        run: ./gradlew build
+
+      - name: Publish to Maven Central (OSSRH)
+        run: ./gradlew publishMavenPublicationToOSSRHRepository
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+
+      - name: Generate SLSA Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            hibernate-reactive-coroutines/build/libs/*.jar
+            hibernate-reactive-coroutines-spring-boot-starter/build/libs/*.jar
+            hibernate-reactive-coroutines-spring-boot-starter-boot4/build/libs/*.jar
+
+  # Alternative: Publish via Sonatype Central Portal (new method)
+  publish-central-portal:
+    runs-on: ubuntu-latest
+    if: false  # Enable when ready to use Central Portal
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Publish to Sonatype Central Portal
+        run: ./gradlew publishMavenPublicationToSonatypeCentralPortalRepository
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,11 @@ name: Publish to Maven Central
 
 on:
   release:
-    types: [ published ]
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 1.0.0)'
+        description: "Version to publish (e.g., 1.0.0)"
         required: false
         type: string
 
@@ -24,8 +24,8 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -36,11 +36,11 @@ jobs:
       - name: Build and verify
         run: ./gradlew build
 
-      - name: Publish to Maven Central (OSSRH)
-        run: ./gradlew publishMavenPublicationToOSSRHRepository
+      - name: Publish to Maven Central
+        run: ./gradlew publishMavenPublicationToSonatypeCentralPortalRepository
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
 
@@ -51,35 +51,3 @@ jobs:
             hibernate-reactive-coroutines/build/libs/*.jar
             hibernate-reactive-coroutines-spring-boot-starter/build/libs/*.jar
             hibernate-reactive-coroutines-spring-boot-starter-boot4/build/libs/*.jar
-
-  # Alternative: Publish via Sonatype Central Portal (new method)
-  publish-central-portal:
-    runs-on: ubuntu-latest
-    if: false  # Enable when ready to use Central Portal
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Build
-        run: ./gradlew build
-
-      - name: Publish to Sonatype Central Portal
-        run: ./gradlew publishMavenPublicationToSonatypeCentralPortalRepository
-        env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hibernate Reactive Coroutines
 
-[![](https://jitpack.io/v/clroot/hibernate-reactive-coroutines.svg)](https://jitpack.io/#clroot/hibernate-reactive-coroutines)
+[![Maven Central](https://img.shields.io/maven-central/v/io.clroot/hibernate-reactive-coroutines.svg)](https://central.sonatype.com/artifact/io.clroot/hibernate-reactive-coroutines)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.2.0-blue.svg)](https://kotlinlang.org)
 [![Hibernate Reactive](https://img.shields.io/badge/Hibernate%20Reactive-3.1.0-green.svg)](https://hibernate.org/reactive/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.4%20%7C%204.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
@@ -22,26 +22,52 @@ Hibernate Reactive + Kotlin Coroutines 환경에서 Spring Data JPA의 편의성
 
 ## 설치
 
-```kotlin
-// settings.gradle.kts
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-    }
-}
+### Gradle (Kotlin DSL)
 
-// build.gradle.kts
+```kotlin
 dependencies {
     // Spring Boot 3.x
-    implementation("com.github.clroot.hibernate-reactive-coroutines:hibernate-reactive-coroutines-spring-boot-starter:1.0.0")
+    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0")
     
     // Spring Boot 4.x
-    implementation("com.github.clroot.hibernate-reactive-coroutines:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.0.0")
+    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.0.0")
     
     // DB 드라이버
     implementation("io.vertx:vertx-pg-client:4.5.16")
 }
+```
+
+### Gradle (Groovy)
+
+```groovy
+dependencies {
+    // Spring Boot 3.x
+    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0'
+    
+    // Spring Boot 4.x
+    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.0.0'
+    
+    // DB 드라이버
+    implementation 'io.vertx:vertx-pg-client:4.5.16'
+}
+```
+
+### Maven
+
+```xml
+<!-- Spring Boot 3.x -->
+<dependency>
+    <groupId>io.clroot</groupId>
+    <artifactId>hibernate-reactive-coroutines-spring-boot-starter</artifactId>
+    <version>1.0.0</version>
+</dependency>
+
+<!-- Spring Boot 4.x -->
+<dependency>
+    <groupId>io.clroot</groupId>
+    <artifactId>hibernate-reactive-coroutines-spring-boot-starter-boot4</artifactId>
+    <version>1.0.0</version>
+</dependency>
 ```
 
 ## 빠른 시작

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,18 +80,6 @@ subprojects {
 
         repositories {
             maven {
-                name = "OSSRH"
-                val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-                url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-
-                credentials {
-                    username = findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME")
-                    password = findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD")
-                }
-            }
-
-            maven {
                 name = "SonatypeCentralPortal"
                 url = uri("https://central.sonatype.com/api/v1/publisher/upload")
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,9 +1,0 @@
-jdk:
-  - openjdk21
-
-before_install:
-  - sdk install java 21.0.2-open
-  - sdk use java 21.0.2-open
-
-install:
-  - VERSION=$VERSION ./gradlew publishToMavenLocal -x test


### PR DESCRIPTION
## 개요

Maven Central에 라이브러리를 배포하기 위한 설정을 추가합니다.

## 변경사항

### 빌드 설정 (`build.gradle.kts`)
- GPG 서명 지원 추가 (in-memory key 방식)
- Sonatype Central Portal 저장소 설정
- groupId를 `io.clroot`로 변경

### CI/CD 워크플로우
- `.github/workflows/ci.yml`: 빌드 및 테스트 자동화
- `.github/workflows/publish.yml`: 릴리스 시 Maven Central 배포 + SLSA Provenance 생성

### 문서
- README.md: Maven Central 의존성 좌표로 업데이트
- JitPack 관련 설정 제거 (`jitpack.yml`)

## 배포 전 필요한 작업

### GitHub Secrets 설정
| Secret | 설명 |
|--------|------|
| `SONATYPE_USERNAME` | Sonatype Central Portal 사용자명 |
| `SONATYPE_PASSWORD` | Sonatype Central Portal 토큰 |
| `GPG_SIGNING_KEY` | GPG 비공개 키 (armor format) |
| `GPG_SIGNING_PASSWORD` | GPG 키 비밀번호 |

### Sonatype 설정
- [x] Central Portal 계정 생성
- [x] `io.clroot` 네임스페이스 등록
- [x] DNS TXT 레코드 검증

### GPG 설정
- [x] GPG 키 생성
- [x] 공개키 키서버 등록

## 테스트

- [x] `./gradlew build` 성공
- [x] `./gradlew publishToMavenLocal` 성공
