### PR TITLE
fix: derive safe page count queries

### DIFF
--- a/docs/migration.ko.md
+++ b/docs/migration.ko.md
@@ -18,9 +18,13 @@ Spring Data JPA에서 Hibernate Reactive Coroutines로 전환하는 가이드입
 | LIKE 검색                            |  ✅  | Containing, StartingWith, EndingWith                  |
 | 비교 연산                            |  ✅  | GreaterThan, LessThan, Between 등                     |
 | `@Query` (JPQL)                      |  ✅  | Named/Positional Parameter                            |
-| `@Query` (Native)                    |  ✅  | 읽기만, countQuery 명시 필요                          |
+| `@Query` (Native)                    |  ✅  | 읽기만 지원, Page는 `countQuery` 필요                 |
 | `@Modifying`                         |  ✅  | JPQL UPDATE/DELETE                                    |
 | 페이지네이션 (`Page`, `Slice`)       |  ✅  | 스마트 COUNT 스킵 최적화                              |
+
+`Page`를 반환하는 HQL/JPQL `@Query` 메서드는 단순 엔티티 `SELECT`/`FROM` 쿼리만 COUNT를 자동
+생성합니다. 프로젝션, 조인, 그룹화, 집합 연산, 후행 SELECT, 쿼리 자체 페이지 제한,
+파라미터가 있는 정렬은 `countQuery`를 명시해야 합니다.
 
 ### 트랜잭션
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -20,9 +20,13 @@ A guide for migrating from Spring Data JPA to Hibernate Reactive Coroutines.
 | LIKE search                          |     ✅     | Containing, StartingWith, EndingWith                     |
 | Comparison operators                 |     ✅     | GreaterThan, LessThan, Between, etc.                     |
 | `@Query` (JPQL)                      |     ✅     | Named/Positional Parameters                              |
-| `@Query` (Native)                    |     ✅     | Read-only, countQuery required                           |
+| `@Query` (Native)                    |     ✅     | Read-only; Page requires `countQuery`                    |
 | `@Modifying`                         |     ✅     | JPQL UPDATE/DELETE                                       |
 | Pagination (`Page`, `Slice`)         |     ✅     | Smart COUNT skip optimization                            |
+
+HQL/JPQL `@Query` methods returning `Page` derive COUNT automatically only for simple entity
+`SELECT`/`FROM` queries. Projections, joins, grouping, set operations, trailing selects,
+query-level pagination, and parameterized ordering require an explicit `countQuery`.
 
 ### Transactions
 

--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -153,6 +153,28 @@ interface UserRepository : CoroutineCrudRepository<User, Long> {
 }
 ```
 
+`Page`를 반환하는 `@Query` 메서드는 `SELECT u FROM User u ...` 또는 `FROM User u ...`와 같은
+단순 엔티티 쿼리만 COUNT 쿼리를 자동 생성합니다. 프로젝션, 조인(암시적 조인 포함),
+`GROUP BY`, `HAVING`, 집합 연산, 후행 `SELECT`, 쿼리 자체 페이지 제한, 파라미터가 있는
+`ORDER BY`를 사용하면 `countQuery`를 명시해야 합니다. 자동 생성 시에는
+`ORDER BY u.id DESC` 같은 단순 루트 속성 정렬만 허용됩니다. 함수, 컬렉션 인덱스,
+경로 탐색이 포함된 정렬식은 `countQuery`를 명시해야 합니다. Native Page 쿼리도 항상
+`countQuery`가 필요합니다. `Slice`는 COUNT 쿼리를 실행하지 않습니다.
+
+Hibernate의 요구사항에 따라 각 어노테이션 쿼리 안의 위치 파라미터는 `?1`부터 시작해
+연속되어야 하며 이름표 없는 `?` 파라미터는 지원하지 않습니다. `countQuery`의 모든
+파라미터는 본문 쿼리에도 있어야 합니다. PostgreSQL 달러 인용 리터럴, 한 줄 주석, 중첩
+블록 주석은 Hibernate의 HQL 파서와 Native 쿼리 파라미터 파서에서 일관되게 처리되지
+않으므로 거부됩니다.
+
+```kotlin
+@Query(
+    value = "SELECT u FROM User u LEFT JOIN FETCH u.roles WHERE u.status = :status",
+    countQuery = "SELECT COUNT(u) FROM User u WHERE u.status = :status",
+)
+suspend fun findWithRoles(status: Status, pageable: Pageable): Page<User>
+```
+
 **사용 예시:**
 
 ```kotlin

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -155,6 +155,29 @@ interface UserRepository : CoroutineCrudRepository<User, Long> {
 }
 ```
 
+For `@Query` methods returning `Page`, a count query is derived automatically only for simple
+entity queries such as `SELECT u FROM User u ...` or `FROM User u ...`. Declare `countQuery`
+explicitly when the query contains projections, joins (including implicit joins), `GROUP BY`,
+`HAVING`, set operations, trailing `SELECT`, query-level pagination, or a parameterized
+`ORDER BY`. Automatic derivation accepts only simple root-property ordering such as
+`ORDER BY u.id DESC`; functions, collection indexing, and path navigation in an order expression
+require an explicit `countQuery`. Native page queries always require an explicit `countQuery`.
+`Slice` does not run a count query.
+
+Within each annotated query, positional parameters must start at `?1` and remain contiguous, as
+required by Hibernate; unlabeled `?` parameters are not supported. Every `countQuery` parameter
+must also appear in the content query. PostgreSQL dollar-quoted literals, line comments, and nested
+block comments are rejected because their parameter parsing is not consistent across Hibernate's
+HQL and native-query parsers.
+
+```kotlin
+@Query(
+    value = "SELECT u FROM User u LEFT JOIN FETCH u.roles WHERE u.status = :status",
+    countQuery = "SELECT COUNT(u) FROM User u WHERE u.status = :status",
+)
+suspend fun findWithRoles(status: Status, pageable: Pageable): Page<User>
+```
+
 **Usage Example:**
 
 ```kotlin

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/PaginationOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/PaginationOperations.kt
@@ -176,7 +176,7 @@ internal class PaginationOperations<T : Any>(
                 session.createQuery(countHql, Long::class.javaObjectType)
             }
 
-            queryOps.bindAnnotatedParameters(query, prepared, args)
+            queryOps.bindAnnotatedCountParameters(query, prepared, args)
             query.singleResult
         } ?: 0L
     }

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
@@ -1,12 +1,14 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
+import io.clroot.hibernate.reactive.spring.boot.repository.query.CountQueryDeriver
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Modifying
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Param
 import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
 import io.clroot.hibernate.reactive.spring.boot.repository.query.PartTreeHqlBuilder
 import io.clroot.hibernate.reactive.spring.boot.repository.query.PreparedQueryMethod
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
-import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryConstants.ORDER_BY_REGEX
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryParameterParser
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryParameters
 import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryReturnType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -40,12 +42,6 @@ internal class QueryMethodParser(
             "findById", "findAll", "findAllById",
             "existsById", "count",
             "deleteById", "delete", "deleteAllById", "deleteAll",
-        )
-
-        /** SELECT ~ FROM 패턴 (COUNT 쿼리 변환용) */
-        private val SELECT_FROM_REGEX = Regex(
-            "SELECT\\s+.*?\\s+FROM",
-            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
         )
     }
 
@@ -116,14 +112,13 @@ internal class QueryMethodParser(
         }
 
         val query = queryAnnotation.value
-        val parameterStyle = detectParameterStyle(query)
-        val parameterNames = if (parameterStyle == ParameterStyle.NAMED) {
-            extractParameterNames(method)
-        } else {
-            emptyList()
-        }
-
         val countHql = generateCountHqlIfNeeded(returnType, queryAnnotation, query)
+        val queryParameters = QueryParameterParser.parse(query)
+        val countParameters = countHql
+            ?.let(QueryParameterParser::parse)
+            ?: QueryParameters(ParameterStyle.NONE)
+        val argumentNames = extractParameterNames(method)
+        validateQueryParameters(method, queryParameters, countParameters, argumentNames)
 
         return PreparedQueryMethod(
             method = method,
@@ -135,8 +130,8 @@ internal class QueryMethodParser(
             isAnnotatedQuery = true,
             isNativeQuery = queryAnnotation.nativeQuery,
             isModifying = isModifying,
-            parameterStyle = parameterStyle,
-            parameterNames = parameterNames,
+            parameterStyle = queryParameters.style,
+            parameterNames = argumentNames,
         )
     }
 
@@ -158,12 +153,12 @@ internal class QueryMethodParser(
         if (returnType != QueryReturnType.PAGE) return null
 
         return when {
-            queryAnnotation.countQuery.isNotEmpty() -> queryAnnotation.countQuery
+            queryAnnotation.countQuery.isNotBlank() -> queryAnnotation.countQuery
             queryAnnotation.nativeQuery -> throw IllegalStateException(
                 "Native query with Page return type requires explicit countQuery",
             )
 
-            else -> generateCountQuery(query)
+            else -> CountQueryDeriver.derive(query)
         }
     }
 
@@ -250,18 +245,62 @@ internal class QueryMethodParser(
     // 파라미터 분석
     // ============================================
 
-    private fun detectParameterStyle(query: String): ParameterStyle {
-        val hasNamed = query.contains(Regex(":\\w+"))
-        val hasPositional = query.contains(Regex("\\?\\d+"))
-
-        return when {
-            hasNamed && hasPositional -> throw IllegalStateException(
-                "Query mixes named (:name) and positional (?1) parameters",
+    private fun validateQueryParameters(
+        method: Method,
+        query: QueryParameters,
+        count: QueryParameters,
+        argumentNames: List<String>,
+    ) {
+        val duplicateName = argumentNames
+            .groupingBy { it }
+            .eachCount()
+            .entries
+            .firstOrNull { it.value > 1 }
+            ?.key
+        if (duplicateName != null) {
+            throw IllegalStateException(
+                "Method '${method.name}' declares duplicate query parameter name '$duplicateName'",
             )
+        }
 
-            hasNamed -> ParameterStyle.NAMED
-            hasPositional -> ParameterStyle.POSITIONAL
-            else -> ParameterStyle.NONE
+        if (query.style != ParameterStyle.NONE && count.style != ParameterStyle.NONE &&
+            query.style != count.style
+        ) {
+            throw IllegalStateException(
+                "Query and countQuery for method '${method.name}' use different parameter styles",
+            )
+        }
+
+        val countOnlyName = count.names.firstOrNull { it !in query.names }
+        if (countOnlyName != null) {
+            throw IllegalStateException(
+                "countQuery for method '${method.name}' references parameter '$countOnlyName' " +
+                        "that is not used by the content query",
+            )
+        }
+        val countOnlyPosition = count.positions.firstOrNull { it !in query.positions }
+        if (countOnlyPosition != null) {
+            throw IllegalStateException(
+                "countQuery for method '${method.name}' references parameter ?$countOnlyPosition " +
+                        "that is not used by the content query",
+            )
+        }
+
+        val unknownNames = (query.names + count.names).distinct() - argumentNames.toSet()
+        if (unknownNames.isNotEmpty()) {
+            throw IllegalStateException(
+                "Query for method '${method.name}' references unknown parameter '${unknownNames.first()}'",
+            )
+        }
+
+        val argumentCount = argumentNames.size
+        val invalidPosition = (query.positions + count.positions)
+            .firstOrNull { it > argumentCount }
+        if (invalidPosition != null) {
+            throw IllegalStateException(
+                "Query for method '${method.name}' references positional parameter ?$invalidPosition " +
+                        "but has only $argumentCount query arguments",
+            )
         }
     }
 
@@ -272,12 +311,13 @@ internal class QueryMethodParser(
             ?: emptyList()
 
         return method.parameters
-            .filter { it.type != Continuation::class.java }
-            .filter { !Pageable::class.java.isAssignableFrom(it.type) }
-            .filter { !Sort::class.java.isAssignableFrom(it.type) }
-            .mapIndexed { index, param ->
+            .mapIndexed { index, param -> param to kotlinParams.getOrNull(index)?.name }
+            .filter { (param) -> param.type != Continuation::class.java }
+            .filter { (param) -> !Pageable::class.java.isAssignableFrom(param.type) }
+            .filter { (param) -> !Sort::class.java.isAssignableFrom(param.type) }
+            .map { (param, kotlinName) ->
                 param.getAnnotation(Param::class.java)?.value
-                    ?: kotlinParams.getOrNull(index)?.name
+                    ?: kotlinName
                     ?: param.name
             }
     }
@@ -355,23 +395,4 @@ internal class QueryMethodParser(
         }
     }
 
-    // ============================================
-    // COUNT 쿼리 생성
-    // ============================================
-
-    private fun generateCountQuery(query: String): String {
-        val normalized = query.trim()
-
-        return when {
-            normalized.startsWith("FROM", ignoreCase = true) ->
-                "SELECT COUNT(*) $normalized".replace(ORDER_BY_REGEX, "")
-
-            normalized.startsWith("SELECT", ignoreCase = true) ->
-                normalized
-                    .replaceFirst(SELECT_FROM_REGEX, "SELECT COUNT(*) FROM")
-                    .replace(ORDER_BY_REGEX, "")
-
-            else -> throw IllegalStateException("Cannot generate count query from: $query")
-        }
-    }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
@@ -164,19 +164,40 @@ internal class QueryOperations<T : Any>(
     ) {
         when (prepared.parameterStyle) {
             ParameterStyle.NAMED -> {
-                prepared.parameterNames.forEachIndexed { index, name ->
-                    query.setParameter(name, args[index])
+                prepared.annotatedParameters.names.forEach { name ->
+                    query.setParameter(name, args[prepared.parameterNames.indexOf(name)])
                 }
             }
 
             ParameterStyle.POSITIONAL -> {
-                args.forEachIndexed { index, arg ->
-                    query.setParameter(index + 1, arg)
+                prepared.annotatedParameters.positions.forEach { position ->
+                    query.setParameter(position, args[position - 1])
                 }
             }
 
-            ParameterStyle.NONE -> { /* 파라미터 없음 */
+            ParameterStyle.NONE -> Unit
+        }
+    }
+
+    internal fun <R> bindAnnotatedCountParameters(
+        query: Mutiny.SelectionQuery<R>,
+        prepared: PreparedQueryMethod,
+        args: List<Any?>,
+    ) {
+        when (prepared.countAnnotatedParameters.style) {
+            ParameterStyle.NAMED -> {
+                prepared.countAnnotatedParameters.names.forEach { name ->
+                    query.setParameter(name, args[prepared.parameterNames.indexOf(name)])
+                }
             }
+
+            ParameterStyle.POSITIONAL -> {
+                prepared.countAnnotatedParameters.positions.forEach { position ->
+                    query.setParameter(position, args[position - 1])
+                }
+            }
+
+            ParameterStyle.NONE -> Unit
         }
     }
 
@@ -187,14 +208,14 @@ internal class QueryOperations<T : Any>(
     ) {
         when (prepared.parameterStyle) {
             ParameterStyle.NAMED -> {
-                prepared.parameterNames.forEachIndexed { index, name ->
-                    query.setParameter(name, args[index])
+                prepared.annotatedParameters.names.forEach { name ->
+                    query.setParameter(name, args[prepared.parameterNames.indexOf(name)])
                 }
             }
 
             ParameterStyle.POSITIONAL -> {
-                args.forEachIndexed { index, arg ->
-                    query.setParameter(index + 1, arg)
+                prepared.annotatedParameters.positions.forEach { position ->
+                    query.setParameter(position, args[position - 1])
                 }
             }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriver.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriver.kt
@@ -1,0 +1,496 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+import java.util.Locale
+
+internal object CountQueryDeriver {
+    private val selectClauseRegex = Regex(
+        "^SELECT\\s+(?:(DISTINCT)\\s+)?(.+?)\\s+FROM\\s+",
+        setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+    )
+    private val simpleAliasRegex = Regex("[\\p{L}_$][\\p{L}\\p{N}_$]*")
+    private val rootAliasRegex = Regex(
+        "^\\s*(?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`)" +
+                "(?:\\.(?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`))*" +
+                "\\s+(?:AS\\s+)?([\\p{L}_$][\\p{L}\\p{N}_$]*)(?=\\s|$)",
+        RegexOption.IGNORE_CASE,
+    )
+    private val rootFromRegex = Regex(
+        "^\\s*((?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`)" +
+                "(?:\\.(?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`))*)" +
+                "(?:\\s+(?:(AS)\\s+)?([\\p{L}_$][\\p{L}\\p{N}_$]*))?",
+        RegexOption.IGNORE_CASE,
+    )
+    private val separatorRegex = Regex(
+        "(?:\\s|/\\*.*?\\*/)*",
+        RegexOption.DOT_MATCHES_ALL,
+    )
+    private val setOperations = setOf("UNION", "INTERSECT", "EXCEPT")
+    private val setModifiers = setOf("ALL", "DISTINCT")
+    private val paginationClauses = setOf("LIMIT", "OFFSET", "FETCH")
+    private val fetchDirections = setOf("FIRST", "NEXT")
+    private val pathFunctions = setOf("ELEMENT", "VALUE", "KEY", "INDEX", "TREAT")
+    private val clauseStarters = setOf(
+        "WHERE", "GROUP", "HAVING", "ORDER", "JOIN", "LEFT", "RIGHT", "INNER", "OUTER",
+        "FULL", "CROSS", "UNION", "INTERSECT", "EXCEPT", "LIMIT", "OFFSET", "FETCH", "SELECT",
+    )
+
+    private data class QueryToken(
+        val value: String,
+        val start: Int,
+        val end: Int,
+        val qualified: Boolean,
+    )
+
+    private data class ScanResult(
+        val tokens: List<QueryToken>,
+        val allTokens: List<QueryToken>,
+        val bindParameters: List<Int>,
+        val topLevelCommas: List<Int>,
+        val quotedQualifiedSegments: List<Int>,
+    )
+
+    private data class RootAlias(
+        val value: String?,
+        val end: Int,
+        val fromEnd: Int,
+    )
+
+    private enum class ScanState {
+        DEFAULT,
+        SINGLE_QUOTE,
+        DOUBLE_QUOTE,
+        BACKTICK,
+        BLOCK_COMMENT,
+    }
+
+    fun derive(query: String): String {
+        val normalized = query.trim()
+        val scan = scan(normalized)
+        val tokens = scan.tokens
+        val rootAlias = findRootAlias(normalized)
+        val structuralTokens = rootAlias
+            ?.let { alias -> tokens.filter { it.start >= alias.end } }
+            ?: tokens
+        if (structuralTokens.findSequence(normalized, "GROUP", "BY") != null) {
+            unsupported("GROUP BY")
+        }
+        structuralTokens.findJoin(normalized)?.let(::unsupported)
+        structuralTokens.findSetOperation(normalized)?.let { unsupported(it.value) }
+        structuralTokens.firstOrNull { !it.qualified && it.value == "HAVING" }
+            ?.let { unsupported("HAVING") }
+        structuralTokens.findPaginationClause(normalized)?.let { unsupported(it.value) }
+
+        val orderBy = structuralTokens.findSequence(normalized, "ORDER", "BY")
+        val fromEnd = rootAlias?.fromEnd
+            ?: tokens.firstOrNull { !it.qualified && it.value == "FROM" }?.end
+            ?: unsupported("missing FROM")
+        val countBodyEnd = orderBy?.start ?: normalized.length
+        if (scan.topLevelCommas.any { it > fromEnd && it < countBodyEnd }) {
+            unsupported("multiple query roots")
+        }
+        if (orderBy != null && scan.bindParameters.any { it >= orderBy.start }) {
+            unsupported("parameterized ORDER BY")
+        }
+        if (rootAlias != null && scan.hasUnsafeRootPath(normalized, rootAlias, countBodyEnd)) {
+            unsupported("implicit join")
+        }
+        if (orderBy != null) {
+            val byToken = structuralTokens[structuralTokens.indexOf(orderBy) + 1]
+            if (!normalized.substring(byToken.end).isSafeOrderClause(rootAlias?.value)) {
+                unsupported("complex or implicit join in ORDER BY")
+            }
+        }
+        val queryWithoutOrder = orderBy
+            ?.let { normalized.substring(0, it.start).trimEnd() }
+            ?: normalized
+
+        return when (tokens.firstOrNull()?.value) {
+            "FROM" -> {
+                if (structuralTokens.any { !it.qualified && it.value == "SELECT" }) {
+                    unsupported("trailing SELECT")
+                }
+                "SELECT COUNT(*) $queryWithoutOrder"
+            }
+
+            "SELECT" ->
+                deriveSelectCount(queryWithoutOrder)
+
+            else -> throw IllegalStateException(
+                "Automatic count query derivation requires a SELECT or FROM query",
+            )
+        }
+    }
+
+    private fun deriveSelectCount(query: String): String {
+        val selectClause = selectClauseRegex.find(query)
+            ?: unsupported("complex SELECT")
+        val isDistinct = selectClause.groupValues[1].isNotEmpty()
+        val selection = selectClause.groupValues[2].trim()
+        if (!simpleAliasRegex.matches(selection)) {
+            unsupported("complex SELECT")
+        }
+        val fromClause = query.substring(selectClause.range.last + 1)
+        val rootAlias = rootAliasRegex.find(fromClause)?.groupValues?.get(1)
+            ?: unsupported("complex FROM")
+        if (!selection.equals(rootAlias, ignoreCase = true)) {
+            unsupported("non-entity projection")
+        }
+
+        val countExpression = if (isDistinct) "DISTINCT $selection" else "*"
+        return "SELECT COUNT($countExpression) FROM $fromClause"
+    }
+
+    private fun findRootAlias(query: String): RootAlias? {
+        val tokens = scan(query).tokens
+        val firstToken = tokens.firstOrNull() ?: return null
+        val fromEnd = when (firstToken.value) {
+            "SELECT" -> selectClauseRegex.find(query)?.range?.last?.plus(1) ?: return null
+            "FROM" -> firstToken.end
+            else -> return null
+        }
+        val root = rootFromRegex.find(query.substring(fromEnd)) ?: return null
+        val entity = root.groups[1] ?: return null
+        val explicitAs = root.groups[2] != null
+        val aliasCandidate = root.groups[3]
+        val selection = if (firstToken.value == "SELECT") {
+            selectClauseRegex.find(query)?.groupValues?.get(2)?.trim()
+        } else {
+            null
+        }
+        val aliasEnd = aliasCandidate?.range?.last?.plus(fromEnd)?.plus(1)
+        val nextToken = aliasEnd?.let { end ->
+            tokens.firstOrNull { it.start >= end }
+        }
+        val alias = aliasCandidate?.takeIf {
+            explicitAs || it.value.uppercase(Locale.ROOT) !in clauseStarters ||
+                    it.value.equals(selection, ignoreCase = true) ||
+                    it.value.equals("JOIN", ignoreCase = true) &&
+                    (nextToken == null || nextToken.value in aliasFollowingClauses)
+        }
+        val rootEnd = alias?.range?.last?.plus(1) ?: entity.range.last + 1
+        return RootAlias(
+            value = alias?.value,
+            end = fromEnd + rootEnd,
+            fromEnd = fromEnd,
+        )
+    }
+
+    private fun unsupported(feature: String): Nothing {
+        throw IllegalStateException(
+            "Automatic count query derivation does not support $feature; declare countQuery explicitly",
+        )
+    }
+
+    private val aliasFollowingClauses = setOf(
+        "WHERE", "GROUP", "HAVING", "ORDER", "LIMIT", "OFFSET", "JOIN",
+    )
+
+    private fun List<QueryToken>.findSequence(query: String, vararg values: String): QueryToken? {
+        if (size < values.size) return null
+        return indices
+            .take(size - values.size + 1)
+            .firstOrNull { index ->
+                values.indices.all { offset ->
+                    val token = this[index + offset]
+                    val previous = getOrNull(index + offset - 1)
+                    !token.qualified &&
+                            token.value == values[offset] &&
+                            (previous == null || offset == 0 || query.hasOnlySeparators(previous.end, token.start))
+                }
+            }
+            ?.let(::get)
+    }
+
+    private fun List<QueryToken>.findJoin(query: String): String? {
+        return indices.firstNotNullOfOrNull { index ->
+            val join = this[index]
+            val next = getOrNull(index + 1)
+            if (join.qualified || join.value != "JOIN") return@firstNotNullOfOrNull null
+
+            val nextTokenStartsTarget = next != null && query.hasOnlySeparators(join.end, next.start)
+            val nextCharacter = query.nextCodeCharacter(join.end)
+            if (!nextTokenStartsTarget && nextCharacter !in setOf('`', '(')) {
+                return@firstNotNullOfOrNull null
+            }
+
+            if (next?.value == "FETCH" && nextTokenStartsTarget) "JOIN FETCH" else "JOIN"
+        }
+    }
+
+    private fun List<QueryToken>.findPaginationClause(query: String): QueryToken? {
+        return firstOrNull { token ->
+            if (token.qualified || token.value !in paginationClauses) return@firstOrNull false
+            val nextCharacter = query.nextCodeCharacter(token.end)
+            when (token.value) {
+                "FETCH" -> {
+                    val index = indexOf(token)
+                    val next = getOrNull(index + 1)
+                    next != null && next.value in fetchDirections &&
+                            query.hasOnlySeparators(token.end, next.start)
+                }
+
+                else -> nextCharacter?.isDigit() == true || nextCharacter == ':' || nextCharacter == '?'
+            }
+        }
+    }
+
+    private fun List<QueryToken>.findSetOperation(query: String): QueryToken? {
+        for (index in indices) {
+            val operation = this[index]
+            if (operation.qualified || operation.value !in setOperations) continue
+            if (query.nextCodeCharacter(operation.end) == '(') return operation
+
+            var nextIndex = index + 1
+            val modifier = getOrNull(nextIndex)
+            var previous = operation
+            if (modifier != null && modifier.value in setModifiers &&
+                query.hasOnlySeparators(operation.end, modifier.start)
+            ) {
+                if (query.nextCodeCharacter(modifier.end) == '(') return operation
+                previous = modifier
+                nextIndex++
+            }
+            val next = getOrNull(nextIndex)
+            val operandStartsQuery = next?.value in setOf("SELECT", "FROM", "WHERE", "ORDER")
+            if (next != null && !next.qualified && operandStartsQuery &&
+                query.hasOnlySeparators(previous.end, next.start)
+            ) {
+                return operation
+            }
+        }
+        return null
+    }
+
+    private fun scan(query: String): ScanResult {
+        val tokens = mutableListOf<QueryToken>()
+        val allTokens = mutableListOf<QueryToken>()
+        val bindParameters = mutableListOf<Int>()
+        val topLevelCommas = mutableListOf<Int>()
+        val quotedQualifiedSegments = mutableListOf<Int>()
+        var state = ScanState.DEFAULT
+        var depth = 0
+        var index = 0
+
+        while (index < query.length) {
+            val current = query[index]
+            val next = query.getOrNull(index + 1)
+
+            when (state) {
+                ScanState.SINGLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'' && next == '\'') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'') state = ScanState.DEFAULT
+                }
+
+                ScanState.DOUBLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"' && next == '"') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"') state = ScanState.DEFAULT
+                }
+
+                ScanState.BACKTICK -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`' && next == '`') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`') state = ScanState.DEFAULT
+                }
+
+                ScanState.BLOCK_COMMENT -> {
+                    if (current == '/' && next == '*') malformed()
+                    if (current == '*' && next == '/') {
+                        state = ScanState.DEFAULT
+                        index += 2
+                        continue
+                    }
+                }
+
+                ScanState.DEFAULT -> when {
+                    current == '\'' -> state = ScanState.SINGLE_QUOTE
+                    current == '"' -> state = ScanState.DOUBLE_QUOTE
+                    current == '`' -> {
+                        if (query.previousSignificant(index) == '.') {
+                            quotedQualifiedSegments += index
+                        }
+                        state = ScanState.BACKTICK
+                    }
+                    current == '*' && next == '/' -> malformed()
+                    current == '$' && query.getOrNull(index - 1)?.isIdentifierPart() != true &&
+                            query.dollarDelimiterAt(index) != null -> malformed()
+                    current == '-' && next == '-' -> {
+                        malformed()
+                    }
+
+                    current == '/' && next == '*' -> {
+                        state = ScanState.BLOCK_COMMENT
+                        index += 2
+                        continue
+                    }
+
+                    current == '(' -> depth++
+                    current == ')' -> {
+                        if (depth == 0) malformed()
+                        depth--
+                    }
+
+                    (current == ':' && next?.isIdentifierStart() == true) ||
+                            (current == '?' && next?.isDigit() == true) -> bindParameters += index
+
+                    depth == 0 && current == ',' -> topLevelCommas += index
+
+                    current.isIdentifierStart() -> {
+                        val start = index
+                        index++
+                        while (index < query.length && query[index].isIdentifierPart()) {
+                            index++
+                        }
+                        val previousSignificant = query.previousSignificant(start)
+                        val nextSignificant = query.nextSignificant(index)
+                        val token = QueryToken(
+                            value = query.substring(start, index).uppercase(Locale.ROOT),
+                            start = start,
+                            end = index,
+                            qualified = previousSignificant == '.' || nextSignificant == '.',
+                        )
+                        allTokens += token
+                        if (depth == 0) tokens += token
+                        continue
+                    }
+                }
+            }
+
+            index++
+        }
+
+        if (depth != 0 || state != ScanState.DEFAULT) {
+            malformed()
+        }
+        return ScanResult(tokens, allTokens, bindParameters, topLevelCommas, quotedQualifiedSegments)
+    }
+
+    private fun ScanResult.hasUnsafeRootPath(
+        query: String,
+        rootAlias: RootAlias,
+        end: Int,
+    ): Boolean {
+        if (quotedQualifiedSegments.any { it > rootAlias.end && it < end }) return true
+        val relevantTokens = allTokens.filter { it.start >= rootAlias.end && it.start < end }
+        if (relevantTokens.any { token ->
+                !token.qualified && token.value in pathFunctions &&
+                        query.nextCodeCharacter(token.end) == '('
+            }
+        ) {
+            return true
+        }
+
+        val rootAliasValue = rootAlias.value
+        if (rootAliasValue == null) {
+            return relevantTokens.indices.any { index ->
+                val property = relevantTokens[index]
+                if (query.nextCodeCharacter(property.end) == '[') return@any true
+                val nestedProperty = relevantTokens.getOrNull(index + 1) ?: return@any false
+                query.hasOnlyPathSeparator(property.end, nestedProperty.start)
+            }
+        }
+
+        for (index in relevantTokens.indices) {
+            val alias = relevantTokens[index]
+            if (!alias.value.equals(rootAliasValue, ignoreCase = true)) continue
+            val property = relevantTokens.getOrNull(index + 1) ?: continue
+            if (!query.hasOnlyPathSeparator(alias.end, property.start)) continue
+            if (query.nextCodeCharacter(property.end) == '[') return true
+            val nestedProperty = relevantTokens.getOrNull(index + 2) ?: continue
+            if (query.hasOnlyPathSeparator(property.end, nestedProperty.start)) return true
+        }
+        return false
+    }
+
+    private fun String.isSafeOrderClause(rootAlias: String?): Boolean {
+        val identifier = "[\\p{L}_$][\\p{L}\\p{N}_$]*"
+        val property = rootAlias
+            ?.let { "(?:(?:${Regex.escape(it)})\\s*\\.\\s*)?$identifier" }
+            ?: identifier
+        val item = "$property(?:\\s+(?:ASC|DESC))?(?:\\s+NULLS\\s+(?:FIRST|LAST))?"
+        return Regex(
+            "^\\s*$item(?:\\s*,\\s*$item)*\\s*$",
+            RegexOption.IGNORE_CASE,
+        ).matches(this)
+    }
+
+    private fun Char.isIdentifierStart(): Boolean = isLetter() || this == '_' || this == '$'
+
+    private fun Char.isIdentifierPart(): Boolean = isLetterOrDigit() || this == '_' || this == '$'
+
+    private fun String.dollarDelimiterAt(start: Int): String? {
+        var cursor = start + 1
+        if (getOrNull(cursor) == '$') return substring(start, cursor + 1)
+        if (getOrNull(cursor)?.let { it.isLetter() || it == '_' } != true) return null
+        cursor++
+        while (getOrNull(cursor)?.let { it.isLetterOrDigit() || it == '_' } == true) cursor++
+        if (getOrNull(cursor) != '$') return null
+        return substring(start, cursor + 1)
+    }
+
+    private fun String.previousSignificant(index: Int): Char? {
+        var cursor = index - 1
+        while (cursor >= 0 && this[cursor].isWhitespace()) cursor--
+        return getOrNull(cursor)
+    }
+
+    private fun String.nextSignificant(index: Int): Char? {
+        var cursor = index
+        while (cursor < length && this[cursor].isWhitespace()) cursor++
+        return getOrNull(cursor)
+    }
+
+    private fun String.hasOnlySeparators(start: Int, end: Int): Boolean {
+        return separatorRegex.matches(substring(start, end))
+    }
+
+    private fun String.hasOnlyPathSeparator(start: Int, end: Int): Boolean {
+        val fragment = substring(start, end)
+        val dot = fragment.indexOf('.')
+        return dot >= 0 && fragment.indexOf('.', dot + 1) < 0 &&
+                separatorRegex.matches(fragment.substring(0, dot)) &&
+                separatorRegex.matches(fragment.substring(dot + 1))
+    }
+
+    private fun String.nextCodeCharacter(index: Int): Char? {
+        var cursor = index
+        while (cursor < length) {
+            when {
+                this[cursor].isWhitespace() -> cursor++
+                startsWith("/*", cursor) -> {
+                    val end = indexOf("*/", cursor + 2)
+                    if (end < 0) return null
+                    cursor = end + 2
+                }
+
+                else -> return this[cursor]
+            }
+        }
+        return null
+    }
+
+    private fun malformed(): Nothing {
+        throw IllegalStateException(
+            "Automatic count query derivation cannot parse the query; declare countQuery explicitly",
+        )
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
@@ -32,4 +32,14 @@ data class PreparedQueryMethod(
     val isModifying: Boolean = false,
     val parameterStyle: ParameterStyle = ParameterStyle.NONE,
     val parameterNames: List<String> = emptyList(),
-)
+) {
+    internal val annotatedParameters: QueryParameters by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        QueryParameterParser.parse(hql)
+    }
+
+    internal val countAnnotatedParameters: QueryParameters by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        countHql
+            ?.let(QueryParameterParser::parse)
+            ?: QueryParameters(ParameterStyle.NONE)
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParser.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParser.kt
@@ -1,0 +1,161 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+internal data class QueryParameters(
+    val style: ParameterStyle,
+    val names: List<String> = emptyList(),
+    val positions: List<Int> = emptyList(),
+)
+
+internal object QueryParameterParser {
+    private enum class State {
+        DEFAULT,
+        SINGLE_QUOTE,
+        DOUBLE_QUOTE,
+        BACKTICK,
+        BLOCK_COMMENT,
+    }
+
+    fun parse(query: String): QueryParameters {
+        val names = linkedSetOf<String>()
+        val positions = linkedSetOf<Int>()
+        var state = State.DEFAULT
+        var index = 0
+
+        while (index < query.length) {
+            val current = query[index]
+            val next = query.getOrNull(index + 1)
+            val openingDollarDelimiter = if (state == State.DEFAULT && current == '$' &&
+                query.getOrNull(index - 1)?.isIdentifierPart() != true
+            ) {
+                query.dollarDelimiterAt(index)
+            } else {
+                null
+            }
+
+            when (state) {
+                State.SINGLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'' && next == '\'') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'') state = State.DEFAULT
+                }
+
+                State.DOUBLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"' && next == '"') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"') state = State.DEFAULT
+                }
+
+                State.BACKTICK -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`' && next == '`') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`') state = State.DEFAULT
+                }
+
+                State.BLOCK_COMMENT -> {
+                    if (current == '/' && next == '*') {
+                        unsupported("nested block comments")
+                    }
+                    if (current == '*' && next == '/') {
+                        state = State.DEFAULT
+                        index += 2
+                        continue
+                    }
+                }
+
+                State.DEFAULT -> when {
+                    current == '\'' -> state = State.SINGLE_QUOTE
+                    current == '"' -> state = State.DOUBLE_QUOTE
+                    current == '`' -> state = State.BACKTICK
+                    current == '*' && next == '/' -> malformed()
+                    openingDollarDelimiter != null -> unsupported("PostgreSQL dollar-quoted literals")
+                    current == '-' && next == '-' -> unsupported("line comments")
+
+                    current == '/' && next == '*' -> {
+                        state = State.BLOCK_COMMENT
+                        index += 2
+                        continue
+                    }
+
+                    current == ':' && query.getOrNull(index - 1) != ':' &&
+                            next?.isIdentifierStart() == true -> {
+                        val start = index + 1
+                        index = start + 1
+                        while (index < query.length && query[index].isIdentifierPart()) index++
+                        names += query.substring(start, index)
+                        continue
+                    }
+
+                    current == '?' && next?.isDigit() == true -> {
+                        val start = index + 1
+                        index = start + 1
+                        while (index < query.length && query[index].isDigit()) index++
+                        val position = query.substring(start, index).toIntOrNull()
+                        if (position == null || position < 1) malformed()
+                        positions += position
+                        continue
+                    }
+
+                    current == '?' -> unsupported("unlabeled positional parameters")
+                }
+            }
+
+            index++
+        }
+
+        if (state != State.DEFAULT) malformed()
+        if (names.isNotEmpty() && positions.isNotEmpty()) {
+            throw IllegalStateException("Query mixes named (:name) and positional (?1) parameters")
+        }
+        if (positions.isNotEmpty() && positions.toSet() != (1..positions.max()).toSet()) {
+            throw IllegalStateException(
+                "Positional query parameters must start at ?1 and be contiguous",
+            )
+        }
+
+        return when {
+            names.isNotEmpty() -> QueryParameters(ParameterStyle.NAMED, names = names.toList())
+            positions.isNotEmpty() -> QueryParameters(ParameterStyle.POSITIONAL, positions = positions.toList())
+            else -> QueryParameters(ParameterStyle.NONE)
+        }
+    }
+
+    private fun Char.isIdentifierStart(): Boolean = isLetter() || this == '_' || this == '$'
+
+    private fun Char.isIdentifierPart(): Boolean = isLetterOrDigit() || this == '_' || this == '$'
+
+    private fun String.dollarDelimiterAt(start: Int): String? {
+        var cursor = start + 1
+        if (getOrNull(cursor) == '$') return substring(start, cursor + 1)
+        if (getOrNull(cursor)?.let { it.isLetter() || it == '_' } != true) return null
+        cursor++
+        while (getOrNull(cursor)?.let { it.isLetterOrDigit() || it == '_' } == true) cursor++
+        if (getOrNull(cursor) != '$') return null
+        return substring(start, cursor + 1)
+    }
+
+    private fun malformed(): Nothing {
+        throw IllegalStateException("Cannot parse query parameters")
+    }
+
+    private fun unsupported(syntax: String): Nothing {
+        throw IllegalStateException("Query parameter parsing does not support $syntax")
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
@@ -1,0 +1,221 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Param
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+class QueryMethodParserTest : DescribeSpec({
+    val parser = QueryMethodParser(User::class.java)
+
+    fun parse(methodName: String) = parser.parse(
+        QueryRepository::class.java.methods.single { it.name == methodName },
+    )
+
+    describe("@Query Page count query derivation") {
+        it("derives a count query for a simple select and removes a multiline order by") {
+            parse("findActive").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.active = true"
+        }
+
+        it("preserves distinct entity semantics") {
+            parse("findDistinct").countHql shouldBe
+                    "SELECT COUNT(DISTINCT e) FROM User e WHERE e.active = true"
+        }
+
+        it("derives a count query from a FROM query") {
+            parse("findFrom").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.active = true"
+        }
+
+        it("ignores structural keywords inside a string literal") {
+            parse("findByNote").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e " +
+                    "WHERE e.note = 'contains ORDER BY, GROUP BY, and JOIN FETCH words'"
+        }
+
+        it("ignores structural keywords inside a comment") {
+            parse("findWithComment").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e /* ORDER BY GROUP BY JOIN FETCH */ " +
+                    "WHERE e.active = true"
+        }
+
+        it("requires an explicit count query for join fetch") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithRoles")
+            }
+
+            error.message shouldContain "does not support JOIN FETCH"
+        }
+
+        it("requires an explicit count query for group by") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("countByActive")
+            }
+
+            error.message shouldContain "does not support GROUP BY"
+        }
+
+        it("requires an explicit count query for set operations") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findCombined")
+            }
+
+            error.message shouldContain "does not support UNION"
+        }
+
+        it("does not accept a blank explicit count query for native paging") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findNativeWithBlankCount")
+            }
+
+            error.message shouldContain "requires explicit countQuery"
+        }
+
+        it("uses an explicit count query for join fetch") {
+            parse("findWithRolesAndCount").countHql shouldBe
+                    "SELECT COUNT(e) FROM User e WHERE e.active = true"
+        }
+
+        it("uses an explicit count query for group by") {
+            parse("countByActiveWithCount").countHql shouldBe
+                    "SELECT COUNT(DISTINCT e.active) FROM User e"
+        }
+
+        it("tracks count query parameters separately from order parameters") {
+            val prepared = parse("findOrderedWithCount")
+
+            prepared.parameterStyle shouldBe ParameterStyle.NAMED
+            prepared.parameterNames shouldBe listOf("active", "priority")
+            prepared.countAnnotatedParameters.style shouldBe ParameterStyle.NAMED
+            prepared.countAnnotatedParameters.names shouldBe listOf("active")
+        }
+
+        it("rejects duplicate method parameter aliases") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithDuplicateAliases")
+            }
+
+            error.message shouldContain "duplicate query parameter name"
+        }
+
+        it("rejects a count query with non-contiguous positional labels") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithNonContiguousCountParameters")
+            }
+
+            error.message shouldContain "must start at ?1 and be contiguous"
+        }
+
+        it("rejects parameters used only by the count query") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithCountOnlyParameter")
+            }
+
+            error.message shouldContain "not used by the content query"
+        }
+    }
+})
+
+private data class User(
+    val id: Long,
+    val active: Boolean,
+    val note: String,
+)
+
+private interface QueryRepository {
+    @Query(
+        """
+        SELECT e FROM User e WHERE e.active = true
+        ORDER BY e.id
+        """,
+    )
+    suspend fun findActive(pageable: Pageable): Page<User>
+
+    @Query("SELECT DISTINCT e FROM User e WHERE e.active = true ORDER BY e.id")
+    suspend fun findDistinct(pageable: Pageable): Page<User>
+
+    @Query("FROM User e WHERE e.active = true ORDER BY e.id")
+    suspend fun findFrom(pageable: Pageable): Page<User>
+
+    @Query(
+        "SELECT e FROM User e " +
+                "WHERE e.note = 'contains ORDER BY, GROUP BY, and JOIN FETCH words' ORDER BY e.id",
+    )
+    suspend fun findByNote(pageable: Pageable): Page<User>
+
+    @Query(
+        "SELECT e FROM User e /* ORDER BY GROUP BY JOIN FETCH */ " +
+                "WHERE e.active = true ORDER BY e.id",
+    )
+    suspend fun findWithComment(pageable: Pageable): Page<User>
+
+    @Query("SELECT e FROM User e LEFT JOIN FETCH e.roles WHERE e.active = true")
+    suspend fun findWithRoles(pageable: Pageable): Page<User>
+
+    @Query("SELECT e.active FROM User e GROUP BY e.active")
+    suspend fun countByActive(pageable: Pageable): Page<Boolean>
+
+    @Query("SELECT e FROM User e UNION SELECT e FROM User e")
+    suspend fun findCombined(pageable: Pageable): Page<User>
+
+    @Query(
+        value = "SELECT * FROM users",
+        nativeQuery = true,
+        countQuery = " ",
+    )
+    suspend fun findNativeWithBlankCount(pageable: Pageable): Page<User>
+
+    @Query(
+        value = "SELECT e FROM User e LEFT JOIN FETCH e.roles WHERE e.active = true",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.active = true",
+    )
+    suspend fun findWithRolesAndCount(pageable: Pageable): Page<User>
+
+    @Query(
+        value = "SELECT e.active FROM User e GROUP BY e.active",
+        countQuery = "SELECT COUNT(DISTINCT e.active) FROM User e",
+    )
+    suspend fun countByActiveWithCount(pageable: Pageable): Page<Boolean>
+
+    @Query(
+        value = "SELECT e FROM User e WHERE e.active = :active " +
+                "ORDER BY CASE WHEN :priority = true THEN 0 ELSE 1 END",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.active = :active",
+    )
+    suspend fun findOrderedWithCount(
+        active: Boolean,
+        priority: Boolean,
+        pageable: Pageable,
+    ): Page<User>
+
+    @Query("SELECT e FROM User e WHERE e.active = :value")
+    suspend fun findWithDuplicateAliases(
+        @Param("value") first: Boolean,
+        @Param("value") second: Boolean,
+    ): List<User>
+
+    @Query(
+        value = "SELECT e FROM User e WHERE e.active = ?1 AND e.note = ?2",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.note = ?2",
+    )
+    suspend fun findWithNonContiguousCountParameters(
+        active: Boolean,
+        note: String,
+        pageable: Pageable,
+    ): Page<User>
+
+    @Query(
+        value = "SELECT e FROM User e",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.active = :active",
+    )
+    suspend fun findWithCountOnlyParameter(
+        active: Boolean,
+        pageable: Pageable,
+    ): Page<User>
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperationsTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperationsTest.kt
@@ -1,11 +1,16 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
+import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
+import io.clroot.hibernate.reactive.spring.boot.repository.query.PreparedQueryMethod
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryReturnType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import org.hibernate.reactive.mutiny.Mutiny
 import jakarta.persistence.metamodel.Attribute
 import jakarta.persistence.metamodel.ManagedType
 import jakarta.persistence.metamodel.Metamodel
@@ -105,6 +110,45 @@ class QueryOperationsTest : DescribeSpec({
             shouldThrow<IllegalArgumentException> {
                 operations.buildSortClause(sort)
             }
+        }
+    }
+
+    describe("annotated count parameters") {
+        it("binds only parameters referenced by the count query") {
+            val query = mockk<Mutiny.SelectionQuery<Long>>(relaxed = true)
+            val prepared = PreparedQueryMethod(
+                method = mockk(),
+                partTree = null,
+                hql = "FROM User e ORDER BY CASE WHEN :priority = true THEN 0 ELSE 1 END",
+                countHql = "SELECT COUNT(e) FROM User e WHERE e.active = :active",
+                parameterBinders = emptyList(),
+                returnType = QueryReturnType.PAGE,
+                parameterStyle = ParameterStyle.NAMED,
+                parameterNames = listOf("active", "priority"),
+            )
+
+            operations.bindAnnotatedCountParameters(query, prepared, listOf(true, false))
+
+            verify(exactly = 1) { query.setParameter("active", true) }
+            verify(exactly = 0) { query.setParameter("priority", any<Boolean>()) }
+        }
+
+        it("binds only positional parameters referenced by the count query") {
+            val query = mockk<Mutiny.SelectionQuery<Long>>(relaxed = true)
+            val prepared = PreparedQueryMethod(
+                method = mockk(),
+                partTree = null,
+                hql = "FROM User e WHERE e.name = ?1 ORDER BY CASE WHEN ?2 = true THEN 0 ELSE 1 END",
+                countHql = "SELECT COUNT(e) FROM User e WHERE e.name = ?1",
+                parameterBinders = emptyList(),
+                returnType = QueryReturnType.PAGE,
+                parameterStyle = ParameterStyle.POSITIONAL,
+            )
+
+            operations.bindAnnotatedCountParameters(query, prepared, listOf("alice", true))
+
+            verify(exactly = 1) { query.setParameter(1, "alice") }
+            verify(exactly = 0) { query.setParameter(2, any<Boolean>()) }
         }
     }
 }) {

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriverTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriverTest.kt
@@ -1,0 +1,265 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class CountQueryDeriverTest : DescribeSpec({
+    describe("CountQueryDeriver") {
+        it("does not treat keyword-shaped path segments as clauses") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM User e " +
+                        "WHERE e.order = 1 AND e.join = true AND e.union = false ORDER BY e.id",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM User e " +
+                    "WHERE e.order = 1 AND e.join = true AND e.union = false"
+        }
+
+        it("keeps dollar signs inside identifiers") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM User e WHERE e.order\$by = true ORDER BY e.id",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.order\$by = true"
+        }
+
+        it("does not treat unqualified soft keywords as clauses") {
+            CountQueryDeriver.derive(
+                "FROM Thing e WHERE order = by AND group = by AND join = fetch",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM Thing e WHERE order = by AND group = by AND join = fetch"
+        }
+
+        it("supports soft keywords as entity aliases") {
+            CountQueryDeriver.derive(
+                "SELECT join FROM User join WHERE join.active = true ORDER BY join.id",
+            ) shouldBe "SELECT COUNT(*) FROM User join WHERE join.active = true"
+            CountQueryDeriver.derive(
+                "FROM User join WHERE join.active = true ORDER BY join.id",
+            ) shouldBe "SELECT COUNT(*) FROM User join WHERE join.active = true"
+            CountQueryDeriver.derive(
+                "FROM User AS select WHERE select.active = true ORDER BY select.id",
+            ) shouldBe "SELECT COUNT(*) FROM User AS select WHERE select.active = true"
+        }
+
+        it("handles aliasless root queries without hiding structural clauses") {
+            CountQueryDeriver.derive(
+                "FROM User WHERE active = true ORDER BY id",
+            ) shouldBe "SELECT COUNT(*) FROM User WHERE active = true"
+
+            listOf(
+                "FROM User GROUP BY active",
+                "FROM User JOIN FETCH roles",
+                "FROM User UNION FROM User",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "declare countQuery explicitly"
+            }
+        }
+
+        it("rejects implicit paths in aliasless predicates") {
+            listOf(
+                "FROM Employee WHERE department.name = :name",
+                "FROM Employee WHERE roles[0].name = :name",
+                "FROM Employee WHERE element(roles).name = :name",
+                "FROM Employee WHERE department.`name` = :name",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "implicit join"
+            }
+        }
+
+        it("does not treat keyword-shaped parameters as clauses") {
+            CountQueryDeriver.derive(
+                "FROM User e WHERE e.rank = :order + :by " +
+                        "AND e.score = :group + :by AND e.other = :join + :fetch",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.rank = :order + :by " +
+                    "AND e.score = :group + :by AND e.other = :join + :fetch"
+        }
+
+        it("keeps escaped double-quoted literals intact") {
+            CountQueryDeriver.derive(
+                """SELECT e FROM User e WHERE e.note = "escaped \" ORDER BY still string" ORDER BY e.id""",
+            ) shouldBe
+                    """SELECT COUNT(*) FROM User e WHERE e.note = "escaped \" ORDER BY still string""""
+        }
+
+        it("ignores keywords inside backtick-quoted identifiers") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM `Union` e ORDER BY e.id",
+            ) shouldBe "SELECT COUNT(*) FROM `Union` e"
+        }
+
+        it("rejects every top-level set operation") {
+            listOf(
+                "SELECT e FROM User e UNION ALL SELECT e FROM User e",
+                "SELECT e FROM User e INTERSECT SELECT e FROM User e",
+                "SELECT e FROM User e EXCEPT SELECT e FROM User e",
+                "FROM User e UNION FROM User e",
+                "SELECT e FROM User e INTERSECT WHERE e.active = true",
+                "SELECT e FROM User e UNION ALL (SELECT e FROM User e)",
+                "SELECT e FROM User e EXCEPT /* comment */ (SELECT e FROM User e)",
+                "SELECT e FROM User e UNION ORDER BY id",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "declare countQuery explicitly"
+            }
+        }
+
+        it("rejects a parameterized order by") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "SELECT e FROM User e WHERE e.active = true " +
+                            "ORDER BY CASE WHEN :priority = true THEN 0 ELSE 1 END",
+                )
+            }
+
+            error.message shouldContain "parameterized ORDER BY"
+        }
+
+        it("rejects projections that may add an implicit join") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "SELECT e.department.name FROM Employee e ORDER BY e.id",
+                )
+            }
+
+            error.message shouldContain "declare countQuery explicitly"
+        }
+
+        it("rejects order paths that may add an implicit join") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "SELECT e FROM Employee e ORDER BY e.department.name",
+                )
+            }
+
+            error.message shouldContain "implicit join in ORDER BY"
+        }
+
+        it("rejects predicate paths that may add an implicit join") {
+            listOf(
+                "SELECT e FROM Employee e WHERE e.department.name = :name",
+                "SELECT e FROM Employee e WHERE lower(e.department.name) = :name",
+                "SELECT e FROM Employee e WHERE e.roles[0].name = :name",
+                "SELECT e FROM Employee e WHERE element(e.roles).name = :name",
+                "SELECT e FROM Employee e WHERE e.`department`.name = :name",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "implicit join"
+            }
+        }
+
+        it("allows simple root properties with standard ordering modifiers") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM Employee e ORDER BY e.name DESC NULLS LAST, id ASC",
+            ) shouldBe "SELECT COUNT(*) FROM Employee e"
+        }
+
+        it("rejects complex order expressions that may add implicit joins") {
+            listOf(
+                "SELECT e FROM Employee e ORDER BY lower(e.name)",
+                "SELECT e FROM Employee e ORDER BY treat(e.department AS Department).name",
+                "SELECT e FROM Employee e ORDER BY e.roles[0].name",
+                "SELECT e FROM Employee e ORDER BY element(e.roles).name",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "complex or implicit join in ORDER BY"
+            }
+        }
+
+        it("rejects joins with backtick-quoted targets") {
+            listOf(
+                "SELECT e FROM User e JOIN `Role` r ON r.user = e",
+                "SELECT e FROM User e LEFT JOIN `Role` r ON r.user = e",
+                "SELECT e FROM User e CROSS JOIN `Role` r",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "JOIN"
+            }
+        }
+
+        it("rejects comma-separated query roots") {
+            listOf(
+                "SELECT e FROM User e, Role r WHERE r.user = e",
+                "FROM User e , Role r WHERE r.user = e",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "multiple query roots"
+            }
+        }
+
+        it("rejects a trailing select clause") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "FROM Book b SELECT b.title ORDER BY b.id",
+                )
+            }
+
+            error.message shouldContain "trailing SELECT"
+        }
+
+        it("rejects pagination clauses") {
+            listOf(
+                "SELECT e FROM User e LIMIT 10",
+                "SELECT e FROM User e OFFSET 5",
+                "SELECT e FROM User e FETCH FIRST 10 ROWS ONLY",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "declare countQuery explicitly"
+            }
+        }
+
+        it("requires an exact query prefix") {
+            shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive("FROMAGE Thing")
+            }
+        }
+
+        it("rejects malformed lexical and parenthesis states") {
+            listOf(
+                "SELECT e FROM User e WHERE (e.active = true",
+                "SELECT e FROM User e WHERE e.active = true)",
+                "SELECT e FROM User e WHERE e.note = 'unterminated",
+                """SELECT e FROM User e WHERE e.note = "unterminated""",
+                "SELECT e FROM `unterminated",
+                "SELECT e FROM User e /* unterminated",
+                "SELECT e FROM User e WHERE e.note = \$\$ ORDER BY marker \$\$ ORDER BY e.id",
+                "SELECT e FROM User e /* outer /* nested */ */ ORDER BY e.id",
+                "SELECT e FROM User e */ ORDER BY e.id",
+                "SELECT e FROM User e WHERE e.x--e.y > :min ORDER BY e.id",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "cannot parse the query"
+            }
+        }
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParserTest.kt
@@ -1,0 +1,108 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class QueryParameterParserTest : DescribeSpec({
+    describe("QueryParameterParser") {
+        it("extracts unique named parameters outside literals and comments") {
+            QueryParameterParser.parse(
+                "SELECT e FROM User e WHERE e.name = :name " +
+                        "AND e.note = ':ignored' /* :alsoIgnored */ OR e.alias = :name",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.NAMED,
+                names = listOf("name"),
+            )
+        }
+
+        it("extracts the positional parameters actually referenced") {
+            QueryParameterParser.parse(
+                "SELECT e FROM User e WHERE e.first = ?2 AND e.second = ?1",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.POSITIONAL,
+                positions = listOf(2, 1),
+            )
+        }
+
+        it("does not treat a PostgreSQL cast as a named parameter") {
+            QueryParameterParser.parse(
+                "SELECT created_at::text FROM users WHERE status = :status",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.NAMED,
+                names = listOf("status"),
+            )
+        }
+
+        it("rejects dollar quotes that Hibernate cannot parameter-parse") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT \$\$:ignored ?1\$\$ FROM users WHERE status = :status",
+                )
+            }
+        }
+
+        it("keeps embedded dollar tags inside PostgreSQL identifiers") {
+            QueryParameterParser.parse(
+                "SELECT foo\$tag\$bar FROM users WHERE status = :status",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.NAMED,
+                names = listOf("status"),
+            )
+        }
+
+        it("rejects nested block comments that Hibernate cannot parameter-parse") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT * FROM users /* outer /* :nested */ ?2 */ WHERE status = :status",
+                )
+            }
+        }
+
+        it("rejects an unmatched block-comment terminator") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT * FROM users */ WHERE status = :status",
+                )
+            }
+        }
+
+        it("rejects line comments that do not have consistent Hibernate parser semantics") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.x--e.y > :min",
+                )
+            }
+        }
+
+        it("rejects an unterminated dollar quote") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse("SELECT \$body\$:ignored FROM users")
+            }
+        }
+
+        it("rejects mixed parameter styles") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.first = :first AND e.second = ?2",
+                )
+            }
+        }
+
+        it("rejects non-contiguous positional labels") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.second = ?2",
+                )
+            }
+        }
+
+        it("rejects unlabeled positional parameters") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.id = ?",
+                )
+            }
+        }
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/PaginationOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/PaginationOperations.kt
@@ -176,7 +176,7 @@ internal class PaginationOperations<T : Any>(
                 session.createQuery(countHql, Long::class.javaObjectType)
             }
 
-            queryOps.bindAnnotatedParameters(query, prepared, args)
+            queryOps.bindAnnotatedCountParameters(query, prepared, args)
             query.singleResult
         } ?: 0L
     }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
@@ -1,12 +1,14 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
+import io.clroot.hibernate.reactive.spring.boot.repository.query.CountQueryDeriver
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Modifying
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Param
 import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
 import io.clroot.hibernate.reactive.spring.boot.repository.query.PartTreeHqlBuilder
 import io.clroot.hibernate.reactive.spring.boot.repository.query.PreparedQueryMethod
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
-import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryConstants.ORDER_BY_REGEX
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryParameterParser
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryParameters
 import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryReturnType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -40,12 +42,6 @@ internal class QueryMethodParser(
             "findById", "findAll", "findAllById",
             "existsById", "count",
             "deleteById", "delete", "deleteAllById", "deleteAll",
-        )
-
-        /** SELECT ~ FROM 패턴 (COUNT 쿼리 변환용) */
-        private val SELECT_FROM_REGEX = Regex(
-            "SELECT\\s+.*?\\s+FROM",
-            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
         )
     }
 
@@ -116,14 +112,13 @@ internal class QueryMethodParser(
         }
 
         val query = queryAnnotation.value
-        val parameterStyle = detectParameterStyle(query)
-        val parameterNames = if (parameterStyle == ParameterStyle.NAMED) {
-            extractParameterNames(method)
-        } else {
-            emptyList()
-        }
-
         val countHql = generateCountHqlIfNeeded(returnType, queryAnnotation, query)
+        val queryParameters = QueryParameterParser.parse(query)
+        val countParameters = countHql
+            ?.let(QueryParameterParser::parse)
+            ?: QueryParameters(ParameterStyle.NONE)
+        val argumentNames = extractParameterNames(method)
+        validateQueryParameters(method, queryParameters, countParameters, argumentNames)
 
         return PreparedQueryMethod(
             method = method,
@@ -135,8 +130,8 @@ internal class QueryMethodParser(
             isAnnotatedQuery = true,
             isNativeQuery = queryAnnotation.nativeQuery,
             isModifying = isModifying,
-            parameterStyle = parameterStyle,
-            parameterNames = parameterNames,
+            parameterStyle = queryParameters.style,
+            parameterNames = argumentNames,
         )
     }
 
@@ -158,12 +153,12 @@ internal class QueryMethodParser(
         if (returnType != QueryReturnType.PAGE) return null
 
         return when {
-            queryAnnotation.countQuery.isNotEmpty() -> queryAnnotation.countQuery
+            queryAnnotation.countQuery.isNotBlank() -> queryAnnotation.countQuery
             queryAnnotation.nativeQuery -> throw IllegalStateException(
                 "Native query with Page return type requires explicit countQuery",
             )
 
-            else -> generateCountQuery(query)
+            else -> CountQueryDeriver.derive(query)
         }
     }
 
@@ -250,18 +245,62 @@ internal class QueryMethodParser(
     // 파라미터 분석
     // ============================================
 
-    private fun detectParameterStyle(query: String): ParameterStyle {
-        val hasNamed = query.contains(Regex(":\\w+"))
-        val hasPositional = query.contains(Regex("\\?\\d+"))
-
-        return when {
-            hasNamed && hasPositional -> throw IllegalStateException(
-                "Query mixes named (:name) and positional (?1) parameters",
+    private fun validateQueryParameters(
+        method: Method,
+        query: QueryParameters,
+        count: QueryParameters,
+        argumentNames: List<String>,
+    ) {
+        val duplicateName = argumentNames
+            .groupingBy { it }
+            .eachCount()
+            .entries
+            .firstOrNull { it.value > 1 }
+            ?.key
+        if (duplicateName != null) {
+            throw IllegalStateException(
+                "Method '${method.name}' declares duplicate query parameter name '$duplicateName'",
             )
+        }
 
-            hasNamed -> ParameterStyle.NAMED
-            hasPositional -> ParameterStyle.POSITIONAL
-            else -> ParameterStyle.NONE
+        if (query.style != ParameterStyle.NONE && count.style != ParameterStyle.NONE &&
+            query.style != count.style
+        ) {
+            throw IllegalStateException(
+                "Query and countQuery for method '${method.name}' use different parameter styles",
+            )
+        }
+
+        val countOnlyName = count.names.firstOrNull { it !in query.names }
+        if (countOnlyName != null) {
+            throw IllegalStateException(
+                "countQuery for method '${method.name}' references parameter '$countOnlyName' " +
+                        "that is not used by the content query",
+            )
+        }
+        val countOnlyPosition = count.positions.firstOrNull { it !in query.positions }
+        if (countOnlyPosition != null) {
+            throw IllegalStateException(
+                "countQuery for method '${method.name}' references parameter ?$countOnlyPosition " +
+                        "that is not used by the content query",
+            )
+        }
+
+        val unknownNames = (query.names + count.names).distinct() - argumentNames.toSet()
+        if (unknownNames.isNotEmpty()) {
+            throw IllegalStateException(
+                "Query for method '${method.name}' references unknown parameter '${unknownNames.first()}'",
+            )
+        }
+
+        val argumentCount = argumentNames.size
+        val invalidPosition = (query.positions + count.positions)
+            .firstOrNull { it > argumentCount }
+        if (invalidPosition != null) {
+            throw IllegalStateException(
+                "Query for method '${method.name}' references positional parameter ?$invalidPosition " +
+                        "but has only $argumentCount query arguments",
+            )
         }
     }
 
@@ -272,12 +311,13 @@ internal class QueryMethodParser(
             ?: emptyList()
 
         return method.parameters
-            .filter { it.type != Continuation::class.java }
-            .filter { !Pageable::class.java.isAssignableFrom(it.type) }
-            .filter { !Sort::class.java.isAssignableFrom(it.type) }
-            .mapIndexed { index, param ->
+            .mapIndexed { index, param -> param to kotlinParams.getOrNull(index)?.name }
+            .filter { (param) -> param.type != Continuation::class.java }
+            .filter { (param) -> !Pageable::class.java.isAssignableFrom(param.type) }
+            .filter { (param) -> !Sort::class.java.isAssignableFrom(param.type) }
+            .map { (param, kotlinName) ->
                 param.getAnnotation(Param::class.java)?.value
-                    ?: kotlinParams.getOrNull(index)?.name
+                    ?: kotlinName
                     ?: param.name
             }
     }
@@ -355,23 +395,4 @@ internal class QueryMethodParser(
         }
     }
 
-    // ============================================
-    // COUNT 쿼리 생성
-    // ============================================
-
-    private fun generateCountQuery(query: String): String {
-        val normalized = query.trim()
-
-        return when {
-            normalized.startsWith("FROM", ignoreCase = true) ->
-                "SELECT COUNT(*) $normalized".replace(ORDER_BY_REGEX, "")
-
-            normalized.startsWith("SELECT", ignoreCase = true) ->
-                normalized
-                    .replaceFirst(SELECT_FROM_REGEX, "SELECT COUNT(*) FROM")
-                    .replace(ORDER_BY_REGEX, "")
-
-            else -> throw IllegalStateException("Cannot generate count query from: $query")
-        }
-    }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
@@ -164,19 +164,40 @@ internal class QueryOperations<T : Any>(
     ) {
         when (prepared.parameterStyle) {
             ParameterStyle.NAMED -> {
-                prepared.parameterNames.forEachIndexed { index, name ->
-                    query.setParameter(name, args[index])
+                prepared.annotatedParameters.names.forEach { name ->
+                    query.setParameter(name, args[prepared.parameterNames.indexOf(name)])
                 }
             }
 
             ParameterStyle.POSITIONAL -> {
-                args.forEachIndexed { index, arg ->
-                    query.setParameter(index + 1, arg)
+                prepared.annotatedParameters.positions.forEach { position ->
+                    query.setParameter(position, args[position - 1])
                 }
             }
 
-            ParameterStyle.NONE -> { /* 파라미터 없음 */
+            ParameterStyle.NONE -> Unit
+        }
+    }
+
+    internal fun <R> bindAnnotatedCountParameters(
+        query: Mutiny.SelectionQuery<R>,
+        prepared: PreparedQueryMethod,
+        args: List<Any?>,
+    ) {
+        when (prepared.countAnnotatedParameters.style) {
+            ParameterStyle.NAMED -> {
+                prepared.countAnnotatedParameters.names.forEach { name ->
+                    query.setParameter(name, args[prepared.parameterNames.indexOf(name)])
+                }
             }
+
+            ParameterStyle.POSITIONAL -> {
+                prepared.countAnnotatedParameters.positions.forEach { position ->
+                    query.setParameter(position, args[position - 1])
+                }
+            }
+
+            ParameterStyle.NONE -> Unit
         }
     }
 
@@ -187,14 +208,14 @@ internal class QueryOperations<T : Any>(
     ) {
         when (prepared.parameterStyle) {
             ParameterStyle.NAMED -> {
-                prepared.parameterNames.forEachIndexed { index, name ->
-                    query.setParameter(name, args[index])
+                prepared.annotatedParameters.names.forEach { name ->
+                    query.setParameter(name, args[prepared.parameterNames.indexOf(name)])
                 }
             }
 
             ParameterStyle.POSITIONAL -> {
-                args.forEachIndexed { index, arg ->
-                    query.setParameter(index + 1, arg)
+                prepared.annotatedParameters.positions.forEach { position ->
+                    query.setParameter(position, args[position - 1])
                 }
             }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriver.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriver.kt
@@ -1,0 +1,496 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+import java.util.Locale
+
+internal object CountQueryDeriver {
+    private val selectClauseRegex = Regex(
+        "^SELECT\\s+(?:(DISTINCT)\\s+)?(.+?)\\s+FROM\\s+",
+        setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+    )
+    private val simpleAliasRegex = Regex("[\\p{L}_$][\\p{L}\\p{N}_$]*")
+    private val rootAliasRegex = Regex(
+        "^\\s*(?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`)" +
+                "(?:\\.(?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`))*" +
+                "\\s+(?:AS\\s+)?([\\p{L}_$][\\p{L}\\p{N}_$]*)(?=\\s|$)",
+        RegexOption.IGNORE_CASE,
+    )
+    private val rootFromRegex = Regex(
+        "^\\s*((?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`)" +
+                "(?:\\.(?:[\\p{L}_$][\\p{L}\\p{N}_$]*|`(?:``|\\\\.|[^`])*`))*)" +
+                "(?:\\s+(?:(AS)\\s+)?([\\p{L}_$][\\p{L}\\p{N}_$]*))?",
+        RegexOption.IGNORE_CASE,
+    )
+    private val separatorRegex = Regex(
+        "(?:\\s|/\\*.*?\\*/)*",
+        RegexOption.DOT_MATCHES_ALL,
+    )
+    private val setOperations = setOf("UNION", "INTERSECT", "EXCEPT")
+    private val setModifiers = setOf("ALL", "DISTINCT")
+    private val paginationClauses = setOf("LIMIT", "OFFSET", "FETCH")
+    private val fetchDirections = setOf("FIRST", "NEXT")
+    private val pathFunctions = setOf("ELEMENT", "VALUE", "KEY", "INDEX", "TREAT")
+    private val clauseStarters = setOf(
+        "WHERE", "GROUP", "HAVING", "ORDER", "JOIN", "LEFT", "RIGHT", "INNER", "OUTER",
+        "FULL", "CROSS", "UNION", "INTERSECT", "EXCEPT", "LIMIT", "OFFSET", "FETCH", "SELECT",
+    )
+
+    private data class QueryToken(
+        val value: String,
+        val start: Int,
+        val end: Int,
+        val qualified: Boolean,
+    )
+
+    private data class ScanResult(
+        val tokens: List<QueryToken>,
+        val allTokens: List<QueryToken>,
+        val bindParameters: List<Int>,
+        val topLevelCommas: List<Int>,
+        val quotedQualifiedSegments: List<Int>,
+    )
+
+    private data class RootAlias(
+        val value: String?,
+        val end: Int,
+        val fromEnd: Int,
+    )
+
+    private enum class ScanState {
+        DEFAULT,
+        SINGLE_QUOTE,
+        DOUBLE_QUOTE,
+        BACKTICK,
+        BLOCK_COMMENT,
+    }
+
+    fun derive(query: String): String {
+        val normalized = query.trim()
+        val scan = scan(normalized)
+        val tokens = scan.tokens
+        val rootAlias = findRootAlias(normalized)
+        val structuralTokens = rootAlias
+            ?.let { alias -> tokens.filter { it.start >= alias.end } }
+            ?: tokens
+        if (structuralTokens.findSequence(normalized, "GROUP", "BY") != null) {
+            unsupported("GROUP BY")
+        }
+        structuralTokens.findJoin(normalized)?.let(::unsupported)
+        structuralTokens.findSetOperation(normalized)?.let { unsupported(it.value) }
+        structuralTokens.firstOrNull { !it.qualified && it.value == "HAVING" }
+            ?.let { unsupported("HAVING") }
+        structuralTokens.findPaginationClause(normalized)?.let { unsupported(it.value) }
+
+        val orderBy = structuralTokens.findSequence(normalized, "ORDER", "BY")
+        val fromEnd = rootAlias?.fromEnd
+            ?: tokens.firstOrNull { !it.qualified && it.value == "FROM" }?.end
+            ?: unsupported("missing FROM")
+        val countBodyEnd = orderBy?.start ?: normalized.length
+        if (scan.topLevelCommas.any { it > fromEnd && it < countBodyEnd }) {
+            unsupported("multiple query roots")
+        }
+        if (orderBy != null && scan.bindParameters.any { it >= orderBy.start }) {
+            unsupported("parameterized ORDER BY")
+        }
+        if (rootAlias != null && scan.hasUnsafeRootPath(normalized, rootAlias, countBodyEnd)) {
+            unsupported("implicit join")
+        }
+        if (orderBy != null) {
+            val byToken = structuralTokens[structuralTokens.indexOf(orderBy) + 1]
+            if (!normalized.substring(byToken.end).isSafeOrderClause(rootAlias?.value)) {
+                unsupported("complex or implicit join in ORDER BY")
+            }
+        }
+        val queryWithoutOrder = orderBy
+            ?.let { normalized.substring(0, it.start).trimEnd() }
+            ?: normalized
+
+        return when (tokens.firstOrNull()?.value) {
+            "FROM" -> {
+                if (structuralTokens.any { !it.qualified && it.value == "SELECT" }) {
+                    unsupported("trailing SELECT")
+                }
+                "SELECT COUNT(*) $queryWithoutOrder"
+            }
+
+            "SELECT" ->
+                deriveSelectCount(queryWithoutOrder)
+
+            else -> throw IllegalStateException(
+                "Automatic count query derivation requires a SELECT or FROM query",
+            )
+        }
+    }
+
+    private fun deriveSelectCount(query: String): String {
+        val selectClause = selectClauseRegex.find(query)
+            ?: unsupported("complex SELECT")
+        val isDistinct = selectClause.groupValues[1].isNotEmpty()
+        val selection = selectClause.groupValues[2].trim()
+        if (!simpleAliasRegex.matches(selection)) {
+            unsupported("complex SELECT")
+        }
+        val fromClause = query.substring(selectClause.range.last + 1)
+        val rootAlias = rootAliasRegex.find(fromClause)?.groupValues?.get(1)
+            ?: unsupported("complex FROM")
+        if (!selection.equals(rootAlias, ignoreCase = true)) {
+            unsupported("non-entity projection")
+        }
+
+        val countExpression = if (isDistinct) "DISTINCT $selection" else "*"
+        return "SELECT COUNT($countExpression) FROM $fromClause"
+    }
+
+    private fun findRootAlias(query: String): RootAlias? {
+        val tokens = scan(query).tokens
+        val firstToken = tokens.firstOrNull() ?: return null
+        val fromEnd = when (firstToken.value) {
+            "SELECT" -> selectClauseRegex.find(query)?.range?.last?.plus(1) ?: return null
+            "FROM" -> firstToken.end
+            else -> return null
+        }
+        val root = rootFromRegex.find(query.substring(fromEnd)) ?: return null
+        val entity = root.groups[1] ?: return null
+        val explicitAs = root.groups[2] != null
+        val aliasCandidate = root.groups[3]
+        val selection = if (firstToken.value == "SELECT") {
+            selectClauseRegex.find(query)?.groupValues?.get(2)?.trim()
+        } else {
+            null
+        }
+        val aliasEnd = aliasCandidate?.range?.last?.plus(fromEnd)?.plus(1)
+        val nextToken = aliasEnd?.let { end ->
+            tokens.firstOrNull { it.start >= end }
+        }
+        val alias = aliasCandidate?.takeIf {
+            explicitAs || it.value.uppercase(Locale.ROOT) !in clauseStarters ||
+                    it.value.equals(selection, ignoreCase = true) ||
+                    it.value.equals("JOIN", ignoreCase = true) &&
+                    (nextToken == null || nextToken.value in aliasFollowingClauses)
+        }
+        val rootEnd = alias?.range?.last?.plus(1) ?: entity.range.last + 1
+        return RootAlias(
+            value = alias?.value,
+            end = fromEnd + rootEnd,
+            fromEnd = fromEnd,
+        )
+    }
+
+    private fun unsupported(feature: String): Nothing {
+        throw IllegalStateException(
+            "Automatic count query derivation does not support $feature; declare countQuery explicitly",
+        )
+    }
+
+    private val aliasFollowingClauses = setOf(
+        "WHERE", "GROUP", "HAVING", "ORDER", "LIMIT", "OFFSET", "JOIN",
+    )
+
+    private fun List<QueryToken>.findSequence(query: String, vararg values: String): QueryToken? {
+        if (size < values.size) return null
+        return indices
+            .take(size - values.size + 1)
+            .firstOrNull { index ->
+                values.indices.all { offset ->
+                    val token = this[index + offset]
+                    val previous = getOrNull(index + offset - 1)
+                    !token.qualified &&
+                            token.value == values[offset] &&
+                            (previous == null || offset == 0 || query.hasOnlySeparators(previous.end, token.start))
+                }
+            }
+            ?.let(::get)
+    }
+
+    private fun List<QueryToken>.findJoin(query: String): String? {
+        return indices.firstNotNullOfOrNull { index ->
+            val join = this[index]
+            val next = getOrNull(index + 1)
+            if (join.qualified || join.value != "JOIN") return@firstNotNullOfOrNull null
+
+            val nextTokenStartsTarget = next != null && query.hasOnlySeparators(join.end, next.start)
+            val nextCharacter = query.nextCodeCharacter(join.end)
+            if (!nextTokenStartsTarget && nextCharacter !in setOf('`', '(')) {
+                return@firstNotNullOfOrNull null
+            }
+
+            if (next?.value == "FETCH" && nextTokenStartsTarget) "JOIN FETCH" else "JOIN"
+        }
+    }
+
+    private fun List<QueryToken>.findPaginationClause(query: String): QueryToken? {
+        return firstOrNull { token ->
+            if (token.qualified || token.value !in paginationClauses) return@firstOrNull false
+            val nextCharacter = query.nextCodeCharacter(token.end)
+            when (token.value) {
+                "FETCH" -> {
+                    val index = indexOf(token)
+                    val next = getOrNull(index + 1)
+                    next != null && next.value in fetchDirections &&
+                            query.hasOnlySeparators(token.end, next.start)
+                }
+
+                else -> nextCharacter?.isDigit() == true || nextCharacter == ':' || nextCharacter == '?'
+            }
+        }
+    }
+
+    private fun List<QueryToken>.findSetOperation(query: String): QueryToken? {
+        for (index in indices) {
+            val operation = this[index]
+            if (operation.qualified || operation.value !in setOperations) continue
+            if (query.nextCodeCharacter(operation.end) == '(') return operation
+
+            var nextIndex = index + 1
+            val modifier = getOrNull(nextIndex)
+            var previous = operation
+            if (modifier != null && modifier.value in setModifiers &&
+                query.hasOnlySeparators(operation.end, modifier.start)
+            ) {
+                if (query.nextCodeCharacter(modifier.end) == '(') return operation
+                previous = modifier
+                nextIndex++
+            }
+            val next = getOrNull(nextIndex)
+            val operandStartsQuery = next?.value in setOf("SELECT", "FROM", "WHERE", "ORDER")
+            if (next != null && !next.qualified && operandStartsQuery &&
+                query.hasOnlySeparators(previous.end, next.start)
+            ) {
+                return operation
+            }
+        }
+        return null
+    }
+
+    private fun scan(query: String): ScanResult {
+        val tokens = mutableListOf<QueryToken>()
+        val allTokens = mutableListOf<QueryToken>()
+        val bindParameters = mutableListOf<Int>()
+        val topLevelCommas = mutableListOf<Int>()
+        val quotedQualifiedSegments = mutableListOf<Int>()
+        var state = ScanState.DEFAULT
+        var depth = 0
+        var index = 0
+
+        while (index < query.length) {
+            val current = query[index]
+            val next = query.getOrNull(index + 1)
+
+            when (state) {
+                ScanState.SINGLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'' && next == '\'') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'') state = ScanState.DEFAULT
+                }
+
+                ScanState.DOUBLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"' && next == '"') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"') state = ScanState.DEFAULT
+                }
+
+                ScanState.BACKTICK -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`' && next == '`') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`') state = ScanState.DEFAULT
+                }
+
+                ScanState.BLOCK_COMMENT -> {
+                    if (current == '/' && next == '*') malformed()
+                    if (current == '*' && next == '/') {
+                        state = ScanState.DEFAULT
+                        index += 2
+                        continue
+                    }
+                }
+
+                ScanState.DEFAULT -> when {
+                    current == '\'' -> state = ScanState.SINGLE_QUOTE
+                    current == '"' -> state = ScanState.DOUBLE_QUOTE
+                    current == '`' -> {
+                        if (query.previousSignificant(index) == '.') {
+                            quotedQualifiedSegments += index
+                        }
+                        state = ScanState.BACKTICK
+                    }
+                    current == '*' && next == '/' -> malformed()
+                    current == '$' && query.getOrNull(index - 1)?.isIdentifierPart() != true &&
+                            query.dollarDelimiterAt(index) != null -> malformed()
+                    current == '-' && next == '-' -> {
+                        malformed()
+                    }
+
+                    current == '/' && next == '*' -> {
+                        state = ScanState.BLOCK_COMMENT
+                        index += 2
+                        continue
+                    }
+
+                    current == '(' -> depth++
+                    current == ')' -> {
+                        if (depth == 0) malformed()
+                        depth--
+                    }
+
+                    (current == ':' && next?.isIdentifierStart() == true) ||
+                            (current == '?' && next?.isDigit() == true) -> bindParameters += index
+
+                    depth == 0 && current == ',' -> topLevelCommas += index
+
+                    current.isIdentifierStart() -> {
+                        val start = index
+                        index++
+                        while (index < query.length && query[index].isIdentifierPart()) {
+                            index++
+                        }
+                        val previousSignificant = query.previousSignificant(start)
+                        val nextSignificant = query.nextSignificant(index)
+                        val token = QueryToken(
+                            value = query.substring(start, index).uppercase(Locale.ROOT),
+                            start = start,
+                            end = index,
+                            qualified = previousSignificant == '.' || nextSignificant == '.',
+                        )
+                        allTokens += token
+                        if (depth == 0) tokens += token
+                        continue
+                    }
+                }
+            }
+
+            index++
+        }
+
+        if (depth != 0 || state != ScanState.DEFAULT) {
+            malformed()
+        }
+        return ScanResult(tokens, allTokens, bindParameters, topLevelCommas, quotedQualifiedSegments)
+    }
+
+    private fun ScanResult.hasUnsafeRootPath(
+        query: String,
+        rootAlias: RootAlias,
+        end: Int,
+    ): Boolean {
+        if (quotedQualifiedSegments.any { it > rootAlias.end && it < end }) return true
+        val relevantTokens = allTokens.filter { it.start >= rootAlias.end && it.start < end }
+        if (relevantTokens.any { token ->
+                !token.qualified && token.value in pathFunctions &&
+                        query.nextCodeCharacter(token.end) == '('
+            }
+        ) {
+            return true
+        }
+
+        val rootAliasValue = rootAlias.value
+        if (rootAliasValue == null) {
+            return relevantTokens.indices.any { index ->
+                val property = relevantTokens[index]
+                if (query.nextCodeCharacter(property.end) == '[') return@any true
+                val nestedProperty = relevantTokens.getOrNull(index + 1) ?: return@any false
+                query.hasOnlyPathSeparator(property.end, nestedProperty.start)
+            }
+        }
+
+        for (index in relevantTokens.indices) {
+            val alias = relevantTokens[index]
+            if (!alias.value.equals(rootAliasValue, ignoreCase = true)) continue
+            val property = relevantTokens.getOrNull(index + 1) ?: continue
+            if (!query.hasOnlyPathSeparator(alias.end, property.start)) continue
+            if (query.nextCodeCharacter(property.end) == '[') return true
+            val nestedProperty = relevantTokens.getOrNull(index + 2) ?: continue
+            if (query.hasOnlyPathSeparator(property.end, nestedProperty.start)) return true
+        }
+        return false
+    }
+
+    private fun String.isSafeOrderClause(rootAlias: String?): Boolean {
+        val identifier = "[\\p{L}_$][\\p{L}\\p{N}_$]*"
+        val property = rootAlias
+            ?.let { "(?:(?:${Regex.escape(it)})\\s*\\.\\s*)?$identifier" }
+            ?: identifier
+        val item = "$property(?:\\s+(?:ASC|DESC))?(?:\\s+NULLS\\s+(?:FIRST|LAST))?"
+        return Regex(
+            "^\\s*$item(?:\\s*,\\s*$item)*\\s*$",
+            RegexOption.IGNORE_CASE,
+        ).matches(this)
+    }
+
+    private fun Char.isIdentifierStart(): Boolean = isLetter() || this == '_' || this == '$'
+
+    private fun Char.isIdentifierPart(): Boolean = isLetterOrDigit() || this == '_' || this == '$'
+
+    private fun String.dollarDelimiterAt(start: Int): String? {
+        var cursor = start + 1
+        if (getOrNull(cursor) == '$') return substring(start, cursor + 1)
+        if (getOrNull(cursor)?.let { it.isLetter() || it == '_' } != true) return null
+        cursor++
+        while (getOrNull(cursor)?.let { it.isLetterOrDigit() || it == '_' } == true) cursor++
+        if (getOrNull(cursor) != '$') return null
+        return substring(start, cursor + 1)
+    }
+
+    private fun String.previousSignificant(index: Int): Char? {
+        var cursor = index - 1
+        while (cursor >= 0 && this[cursor].isWhitespace()) cursor--
+        return getOrNull(cursor)
+    }
+
+    private fun String.nextSignificant(index: Int): Char? {
+        var cursor = index
+        while (cursor < length && this[cursor].isWhitespace()) cursor++
+        return getOrNull(cursor)
+    }
+
+    private fun String.hasOnlySeparators(start: Int, end: Int): Boolean {
+        return separatorRegex.matches(substring(start, end))
+    }
+
+    private fun String.hasOnlyPathSeparator(start: Int, end: Int): Boolean {
+        val fragment = substring(start, end)
+        val dot = fragment.indexOf('.')
+        return dot >= 0 && fragment.indexOf('.', dot + 1) < 0 &&
+                separatorRegex.matches(fragment.substring(0, dot)) &&
+                separatorRegex.matches(fragment.substring(dot + 1))
+    }
+
+    private fun String.nextCodeCharacter(index: Int): Char? {
+        var cursor = index
+        while (cursor < length) {
+            when {
+                this[cursor].isWhitespace() -> cursor++
+                startsWith("/*", cursor) -> {
+                    val end = indexOf("*/", cursor + 2)
+                    if (end < 0) return null
+                    cursor = end + 2
+                }
+
+                else -> return this[cursor]
+            }
+        }
+        return null
+    }
+
+    private fun malformed(): Nothing {
+        throw IllegalStateException(
+            "Automatic count query derivation cannot parse the query; declare countQuery explicitly",
+        )
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
@@ -32,4 +32,14 @@ data class PreparedQueryMethod(
     val isModifying: Boolean = false,
     val parameterStyle: ParameterStyle = ParameterStyle.NONE,
     val parameterNames: List<String> = emptyList(),
-)
+) {
+    internal val annotatedParameters: QueryParameters by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        QueryParameterParser.parse(hql)
+    }
+
+    internal val countAnnotatedParameters: QueryParameters by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        countHql
+            ?.let(QueryParameterParser::parse)
+            ?: QueryParameters(ParameterStyle.NONE)
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParser.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParser.kt
@@ -1,0 +1,161 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+internal data class QueryParameters(
+    val style: ParameterStyle,
+    val names: List<String> = emptyList(),
+    val positions: List<Int> = emptyList(),
+)
+
+internal object QueryParameterParser {
+    private enum class State {
+        DEFAULT,
+        SINGLE_QUOTE,
+        DOUBLE_QUOTE,
+        BACKTICK,
+        BLOCK_COMMENT,
+    }
+
+    fun parse(query: String): QueryParameters {
+        val names = linkedSetOf<String>()
+        val positions = linkedSetOf<Int>()
+        var state = State.DEFAULT
+        var index = 0
+
+        while (index < query.length) {
+            val current = query[index]
+            val next = query.getOrNull(index + 1)
+            val openingDollarDelimiter = if (state == State.DEFAULT && current == '$' &&
+                query.getOrNull(index - 1)?.isIdentifierPart() != true
+            ) {
+                query.dollarDelimiterAt(index)
+            } else {
+                null
+            }
+
+            when (state) {
+                State.SINGLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'' && next == '\'') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '\'') state = State.DEFAULT
+                }
+
+                State.DOUBLE_QUOTE -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"' && next == '"') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '"') state = State.DEFAULT
+                }
+
+                State.BACKTICK -> {
+                    if (current == '\\' && next != null) {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`' && next == '`') {
+                        index += 2
+                        continue
+                    }
+                    if (current == '`') state = State.DEFAULT
+                }
+
+                State.BLOCK_COMMENT -> {
+                    if (current == '/' && next == '*') {
+                        unsupported("nested block comments")
+                    }
+                    if (current == '*' && next == '/') {
+                        state = State.DEFAULT
+                        index += 2
+                        continue
+                    }
+                }
+
+                State.DEFAULT -> when {
+                    current == '\'' -> state = State.SINGLE_QUOTE
+                    current == '"' -> state = State.DOUBLE_QUOTE
+                    current == '`' -> state = State.BACKTICK
+                    current == '*' && next == '/' -> malformed()
+                    openingDollarDelimiter != null -> unsupported("PostgreSQL dollar-quoted literals")
+                    current == '-' && next == '-' -> unsupported("line comments")
+
+                    current == '/' && next == '*' -> {
+                        state = State.BLOCK_COMMENT
+                        index += 2
+                        continue
+                    }
+
+                    current == ':' && query.getOrNull(index - 1) != ':' &&
+                            next?.isIdentifierStart() == true -> {
+                        val start = index + 1
+                        index = start + 1
+                        while (index < query.length && query[index].isIdentifierPart()) index++
+                        names += query.substring(start, index)
+                        continue
+                    }
+
+                    current == '?' && next?.isDigit() == true -> {
+                        val start = index + 1
+                        index = start + 1
+                        while (index < query.length && query[index].isDigit()) index++
+                        val position = query.substring(start, index).toIntOrNull()
+                        if (position == null || position < 1) malformed()
+                        positions += position
+                        continue
+                    }
+
+                    current == '?' -> unsupported("unlabeled positional parameters")
+                }
+            }
+
+            index++
+        }
+
+        if (state != State.DEFAULT) malformed()
+        if (names.isNotEmpty() && positions.isNotEmpty()) {
+            throw IllegalStateException("Query mixes named (:name) and positional (?1) parameters")
+        }
+        if (positions.isNotEmpty() && positions.toSet() != (1..positions.max()).toSet()) {
+            throw IllegalStateException(
+                "Positional query parameters must start at ?1 and be contiguous",
+            )
+        }
+
+        return when {
+            names.isNotEmpty() -> QueryParameters(ParameterStyle.NAMED, names = names.toList())
+            positions.isNotEmpty() -> QueryParameters(ParameterStyle.POSITIONAL, positions = positions.toList())
+            else -> QueryParameters(ParameterStyle.NONE)
+        }
+    }
+
+    private fun Char.isIdentifierStart(): Boolean = isLetter() || this == '_' || this == '$'
+
+    private fun Char.isIdentifierPart(): Boolean = isLetterOrDigit() || this == '_' || this == '$'
+
+    private fun String.dollarDelimiterAt(start: Int): String? {
+        var cursor = start + 1
+        if (getOrNull(cursor) == '$') return substring(start, cursor + 1)
+        if (getOrNull(cursor)?.let { it.isLetter() || it == '_' } != true) return null
+        cursor++
+        while (getOrNull(cursor)?.let { it.isLetterOrDigit() || it == '_' } == true) cursor++
+        if (getOrNull(cursor) != '$') return null
+        return substring(start, cursor + 1)
+    }
+
+    private fun malformed(): Nothing {
+        throw IllegalStateException("Cannot parse query parameters")
+    }
+
+    private fun unsupported(syntax: String): Nothing {
+        throw IllegalStateException("Query parameter parsing does not support $syntax")
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
@@ -1,0 +1,221 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Param
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+class QueryMethodParserTest : DescribeSpec({
+    val parser = QueryMethodParser(User::class.java)
+
+    fun parse(methodName: String) = parser.parse(
+        QueryRepository::class.java.methods.single { it.name == methodName },
+    )
+
+    describe("@Query Page count query derivation") {
+        it("derives a count query for a simple select and removes a multiline order by") {
+            parse("findActive").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.active = true"
+        }
+
+        it("preserves distinct entity semantics") {
+            parse("findDistinct").countHql shouldBe
+                    "SELECT COUNT(DISTINCT e) FROM User e WHERE e.active = true"
+        }
+
+        it("derives a count query from a FROM query") {
+            parse("findFrom").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.active = true"
+        }
+
+        it("ignores structural keywords inside a string literal") {
+            parse("findByNote").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e " +
+                    "WHERE e.note = 'contains ORDER BY, GROUP BY, and JOIN FETCH words'"
+        }
+
+        it("ignores structural keywords inside a comment") {
+            parse("findWithComment").countHql shouldBe
+                    "SELECT COUNT(*) FROM User e /* ORDER BY GROUP BY JOIN FETCH */ " +
+                    "WHERE e.active = true"
+        }
+
+        it("requires an explicit count query for join fetch") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithRoles")
+            }
+
+            error.message shouldContain "does not support JOIN FETCH"
+        }
+
+        it("requires an explicit count query for group by") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("countByActive")
+            }
+
+            error.message shouldContain "does not support GROUP BY"
+        }
+
+        it("requires an explicit count query for set operations") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findCombined")
+            }
+
+            error.message shouldContain "does not support UNION"
+        }
+
+        it("does not accept a blank explicit count query for native paging") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findNativeWithBlankCount")
+            }
+
+            error.message shouldContain "requires explicit countQuery"
+        }
+
+        it("uses an explicit count query for join fetch") {
+            parse("findWithRolesAndCount").countHql shouldBe
+                    "SELECT COUNT(e) FROM User e WHERE e.active = true"
+        }
+
+        it("uses an explicit count query for group by") {
+            parse("countByActiveWithCount").countHql shouldBe
+                    "SELECT COUNT(DISTINCT e.active) FROM User e"
+        }
+
+        it("tracks count query parameters separately from order parameters") {
+            val prepared = parse("findOrderedWithCount")
+
+            prepared.parameterStyle shouldBe ParameterStyle.NAMED
+            prepared.parameterNames shouldBe listOf("active", "priority")
+            prepared.countAnnotatedParameters.style shouldBe ParameterStyle.NAMED
+            prepared.countAnnotatedParameters.names shouldBe listOf("active")
+        }
+
+        it("rejects duplicate method parameter aliases") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithDuplicateAliases")
+            }
+
+            error.message shouldContain "duplicate query parameter name"
+        }
+
+        it("rejects a count query with non-contiguous positional labels") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithNonContiguousCountParameters")
+            }
+
+            error.message shouldContain "must start at ?1 and be contiguous"
+        }
+
+        it("rejects parameters used only by the count query") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findWithCountOnlyParameter")
+            }
+
+            error.message shouldContain "not used by the content query"
+        }
+    }
+})
+
+private data class User(
+    val id: Long,
+    val active: Boolean,
+    val note: String,
+)
+
+private interface QueryRepository {
+    @Query(
+        """
+        SELECT e FROM User e WHERE e.active = true
+        ORDER BY e.id
+        """,
+    )
+    suspend fun findActive(pageable: Pageable): Page<User>
+
+    @Query("SELECT DISTINCT e FROM User e WHERE e.active = true ORDER BY e.id")
+    suspend fun findDistinct(pageable: Pageable): Page<User>
+
+    @Query("FROM User e WHERE e.active = true ORDER BY e.id")
+    suspend fun findFrom(pageable: Pageable): Page<User>
+
+    @Query(
+        "SELECT e FROM User e " +
+                "WHERE e.note = 'contains ORDER BY, GROUP BY, and JOIN FETCH words' ORDER BY e.id",
+    )
+    suspend fun findByNote(pageable: Pageable): Page<User>
+
+    @Query(
+        "SELECT e FROM User e /* ORDER BY GROUP BY JOIN FETCH */ " +
+                "WHERE e.active = true ORDER BY e.id",
+    )
+    suspend fun findWithComment(pageable: Pageable): Page<User>
+
+    @Query("SELECT e FROM User e LEFT JOIN FETCH e.roles WHERE e.active = true")
+    suspend fun findWithRoles(pageable: Pageable): Page<User>
+
+    @Query("SELECT e.active FROM User e GROUP BY e.active")
+    suspend fun countByActive(pageable: Pageable): Page<Boolean>
+
+    @Query("SELECT e FROM User e UNION SELECT e FROM User e")
+    suspend fun findCombined(pageable: Pageable): Page<User>
+
+    @Query(
+        value = "SELECT * FROM users",
+        nativeQuery = true,
+        countQuery = " ",
+    )
+    suspend fun findNativeWithBlankCount(pageable: Pageable): Page<User>
+
+    @Query(
+        value = "SELECT e FROM User e LEFT JOIN FETCH e.roles WHERE e.active = true",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.active = true",
+    )
+    suspend fun findWithRolesAndCount(pageable: Pageable): Page<User>
+
+    @Query(
+        value = "SELECT e.active FROM User e GROUP BY e.active",
+        countQuery = "SELECT COUNT(DISTINCT e.active) FROM User e",
+    )
+    suspend fun countByActiveWithCount(pageable: Pageable): Page<Boolean>
+
+    @Query(
+        value = "SELECT e FROM User e WHERE e.active = :active " +
+                "ORDER BY CASE WHEN :priority = true THEN 0 ELSE 1 END",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.active = :active",
+    )
+    suspend fun findOrderedWithCount(
+        active: Boolean,
+        priority: Boolean,
+        pageable: Pageable,
+    ): Page<User>
+
+    @Query("SELECT e FROM User e WHERE e.active = :value")
+    suspend fun findWithDuplicateAliases(
+        @Param("value") first: Boolean,
+        @Param("value") second: Boolean,
+    ): List<User>
+
+    @Query(
+        value = "SELECT e FROM User e WHERE e.active = ?1 AND e.note = ?2",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.note = ?2",
+    )
+    suspend fun findWithNonContiguousCountParameters(
+        active: Boolean,
+        note: String,
+        pageable: Pageable,
+    ): Page<User>
+
+    @Query(
+        value = "SELECT e FROM User e",
+        countQuery = "SELECT COUNT(e) FROM User e WHERE e.active = :active",
+    )
+    suspend fun findWithCountOnlyParameter(
+        active: Boolean,
+        pageable: Pageable,
+    ): Page<User>
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperationsTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperationsTest.kt
@@ -1,11 +1,16 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
+import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
+import io.clroot.hibernate.reactive.spring.boot.repository.query.PreparedQueryMethod
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryReturnType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import org.hibernate.reactive.mutiny.Mutiny
 import jakarta.persistence.metamodel.Attribute
 import jakarta.persistence.metamodel.ManagedType
 import jakarta.persistence.metamodel.Metamodel
@@ -105,6 +110,45 @@ class QueryOperationsTest : DescribeSpec({
             shouldThrow<IllegalArgumentException> {
                 operations.buildSortClause(sort)
             }
+        }
+    }
+
+    describe("annotated count parameters") {
+        it("binds only parameters referenced by the count query") {
+            val query = mockk<Mutiny.SelectionQuery<Long>>(relaxed = true)
+            val prepared = PreparedQueryMethod(
+                method = mockk(),
+                partTree = null,
+                hql = "FROM User e ORDER BY CASE WHEN :priority = true THEN 0 ELSE 1 END",
+                countHql = "SELECT COUNT(e) FROM User e WHERE e.active = :active",
+                parameterBinders = emptyList(),
+                returnType = QueryReturnType.PAGE,
+                parameterStyle = ParameterStyle.NAMED,
+                parameterNames = listOf("active", "priority"),
+            )
+
+            operations.bindAnnotatedCountParameters(query, prepared, listOf(true, false))
+
+            verify(exactly = 1) { query.setParameter("active", true) }
+            verify(exactly = 0) { query.setParameter("priority", any<Boolean>()) }
+        }
+
+        it("binds only positional parameters referenced by the count query") {
+            val query = mockk<Mutiny.SelectionQuery<Long>>(relaxed = true)
+            val prepared = PreparedQueryMethod(
+                method = mockk(),
+                partTree = null,
+                hql = "FROM User e WHERE e.name = ?1 ORDER BY CASE WHEN ?2 = true THEN 0 ELSE 1 END",
+                countHql = "SELECT COUNT(e) FROM User e WHERE e.name = ?1",
+                parameterBinders = emptyList(),
+                returnType = QueryReturnType.PAGE,
+                parameterStyle = ParameterStyle.POSITIONAL,
+            )
+
+            operations.bindAnnotatedCountParameters(query, prepared, listOf("alice", true))
+
+            verify(exactly = 1) { query.setParameter(1, "alice") }
+            verify(exactly = 0) { query.setParameter(2, any<Boolean>()) }
         }
     }
 }) {

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriverTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriverTest.kt
@@ -1,0 +1,265 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class CountQueryDeriverTest : DescribeSpec({
+    describe("CountQueryDeriver") {
+        it("does not treat keyword-shaped path segments as clauses") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM User e " +
+                        "WHERE e.order = 1 AND e.join = true AND e.union = false ORDER BY e.id",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM User e " +
+                    "WHERE e.order = 1 AND e.join = true AND e.union = false"
+        }
+
+        it("keeps dollar signs inside identifiers") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM User e WHERE e.order\$by = true ORDER BY e.id",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.order\$by = true"
+        }
+
+        it("does not treat unqualified soft keywords as clauses") {
+            CountQueryDeriver.derive(
+                "FROM Thing e WHERE order = by AND group = by AND join = fetch",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM Thing e WHERE order = by AND group = by AND join = fetch"
+        }
+
+        it("supports soft keywords as entity aliases") {
+            CountQueryDeriver.derive(
+                "SELECT join FROM User join WHERE join.active = true ORDER BY join.id",
+            ) shouldBe "SELECT COUNT(*) FROM User join WHERE join.active = true"
+            CountQueryDeriver.derive(
+                "FROM User join WHERE join.active = true ORDER BY join.id",
+            ) shouldBe "SELECT COUNT(*) FROM User join WHERE join.active = true"
+            CountQueryDeriver.derive(
+                "FROM User AS select WHERE select.active = true ORDER BY select.id",
+            ) shouldBe "SELECT COUNT(*) FROM User AS select WHERE select.active = true"
+        }
+
+        it("handles aliasless root queries without hiding structural clauses") {
+            CountQueryDeriver.derive(
+                "FROM User WHERE active = true ORDER BY id",
+            ) shouldBe "SELECT COUNT(*) FROM User WHERE active = true"
+
+            listOf(
+                "FROM User GROUP BY active",
+                "FROM User JOIN FETCH roles",
+                "FROM User UNION FROM User",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "declare countQuery explicitly"
+            }
+        }
+
+        it("rejects implicit paths in aliasless predicates") {
+            listOf(
+                "FROM Employee WHERE department.name = :name",
+                "FROM Employee WHERE roles[0].name = :name",
+                "FROM Employee WHERE element(roles).name = :name",
+                "FROM Employee WHERE department.`name` = :name",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "implicit join"
+            }
+        }
+
+        it("does not treat keyword-shaped parameters as clauses") {
+            CountQueryDeriver.derive(
+                "FROM User e WHERE e.rank = :order + :by " +
+                        "AND e.score = :group + :by AND e.other = :join + :fetch",
+            ) shouldBe
+                    "SELECT COUNT(*) FROM User e WHERE e.rank = :order + :by " +
+                    "AND e.score = :group + :by AND e.other = :join + :fetch"
+        }
+
+        it("keeps escaped double-quoted literals intact") {
+            CountQueryDeriver.derive(
+                """SELECT e FROM User e WHERE e.note = "escaped \" ORDER BY still string" ORDER BY e.id""",
+            ) shouldBe
+                    """SELECT COUNT(*) FROM User e WHERE e.note = "escaped \" ORDER BY still string""""
+        }
+
+        it("ignores keywords inside backtick-quoted identifiers") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM `Union` e ORDER BY e.id",
+            ) shouldBe "SELECT COUNT(*) FROM `Union` e"
+        }
+
+        it("rejects every top-level set operation") {
+            listOf(
+                "SELECT e FROM User e UNION ALL SELECT e FROM User e",
+                "SELECT e FROM User e INTERSECT SELECT e FROM User e",
+                "SELECT e FROM User e EXCEPT SELECT e FROM User e",
+                "FROM User e UNION FROM User e",
+                "SELECT e FROM User e INTERSECT WHERE e.active = true",
+                "SELECT e FROM User e UNION ALL (SELECT e FROM User e)",
+                "SELECT e FROM User e EXCEPT /* comment */ (SELECT e FROM User e)",
+                "SELECT e FROM User e UNION ORDER BY id",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "declare countQuery explicitly"
+            }
+        }
+
+        it("rejects a parameterized order by") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "SELECT e FROM User e WHERE e.active = true " +
+                            "ORDER BY CASE WHEN :priority = true THEN 0 ELSE 1 END",
+                )
+            }
+
+            error.message shouldContain "parameterized ORDER BY"
+        }
+
+        it("rejects projections that may add an implicit join") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "SELECT e.department.name FROM Employee e ORDER BY e.id",
+                )
+            }
+
+            error.message shouldContain "declare countQuery explicitly"
+        }
+
+        it("rejects order paths that may add an implicit join") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "SELECT e FROM Employee e ORDER BY e.department.name",
+                )
+            }
+
+            error.message shouldContain "implicit join in ORDER BY"
+        }
+
+        it("rejects predicate paths that may add an implicit join") {
+            listOf(
+                "SELECT e FROM Employee e WHERE e.department.name = :name",
+                "SELECT e FROM Employee e WHERE lower(e.department.name) = :name",
+                "SELECT e FROM Employee e WHERE e.roles[0].name = :name",
+                "SELECT e FROM Employee e WHERE element(e.roles).name = :name",
+                "SELECT e FROM Employee e WHERE e.`department`.name = :name",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "implicit join"
+            }
+        }
+
+        it("allows simple root properties with standard ordering modifiers") {
+            CountQueryDeriver.derive(
+                "SELECT e FROM Employee e ORDER BY e.name DESC NULLS LAST, id ASC",
+            ) shouldBe "SELECT COUNT(*) FROM Employee e"
+        }
+
+        it("rejects complex order expressions that may add implicit joins") {
+            listOf(
+                "SELECT e FROM Employee e ORDER BY lower(e.name)",
+                "SELECT e FROM Employee e ORDER BY treat(e.department AS Department).name",
+                "SELECT e FROM Employee e ORDER BY e.roles[0].name",
+                "SELECT e FROM Employee e ORDER BY element(e.roles).name",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "complex or implicit join in ORDER BY"
+            }
+        }
+
+        it("rejects joins with backtick-quoted targets") {
+            listOf(
+                "SELECT e FROM User e JOIN `Role` r ON r.user = e",
+                "SELECT e FROM User e LEFT JOIN `Role` r ON r.user = e",
+                "SELECT e FROM User e CROSS JOIN `Role` r",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "JOIN"
+            }
+        }
+
+        it("rejects comma-separated query roots") {
+            listOf(
+                "SELECT e FROM User e, Role r WHERE r.user = e",
+                "FROM User e , Role r WHERE r.user = e",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "multiple query roots"
+            }
+        }
+
+        it("rejects a trailing select clause") {
+            val error = shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive(
+                    "FROM Book b SELECT b.title ORDER BY b.id",
+                )
+            }
+
+            error.message shouldContain "trailing SELECT"
+        }
+
+        it("rejects pagination clauses") {
+            listOf(
+                "SELECT e FROM User e LIMIT 10",
+                "SELECT e FROM User e OFFSET 5",
+                "SELECT e FROM User e FETCH FIRST 10 ROWS ONLY",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "declare countQuery explicitly"
+            }
+        }
+
+        it("requires an exact query prefix") {
+            shouldThrow<IllegalStateException> {
+                CountQueryDeriver.derive("FROMAGE Thing")
+            }
+        }
+
+        it("rejects malformed lexical and parenthesis states") {
+            listOf(
+                "SELECT e FROM User e WHERE (e.active = true",
+                "SELECT e FROM User e WHERE e.active = true)",
+                "SELECT e FROM User e WHERE e.note = 'unterminated",
+                """SELECT e FROM User e WHERE e.note = "unterminated""",
+                "SELECT e FROM `unterminated",
+                "SELECT e FROM User e /* unterminated",
+                "SELECT e FROM User e WHERE e.note = \$\$ ORDER BY marker \$\$ ORDER BY e.id",
+                "SELECT e FROM User e /* outer /* nested */ */ ORDER BY e.id",
+                "SELECT e FROM User e */ ORDER BY e.id",
+                "SELECT e FROM User e WHERE e.x--e.y > :min ORDER BY e.id",
+            ).forEach { query ->
+                val error = shouldThrow<IllegalStateException> {
+                    CountQueryDeriver.derive(query)
+                }
+
+                error.message shouldContain "cannot parse the query"
+            }
+        }
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryParameterParserTest.kt
@@ -1,0 +1,108 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class QueryParameterParserTest : DescribeSpec({
+    describe("QueryParameterParser") {
+        it("extracts unique named parameters outside literals and comments") {
+            QueryParameterParser.parse(
+                "SELECT e FROM User e WHERE e.name = :name " +
+                        "AND e.note = ':ignored' /* :alsoIgnored */ OR e.alias = :name",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.NAMED,
+                names = listOf("name"),
+            )
+        }
+
+        it("extracts the positional parameters actually referenced") {
+            QueryParameterParser.parse(
+                "SELECT e FROM User e WHERE e.first = ?2 AND e.second = ?1",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.POSITIONAL,
+                positions = listOf(2, 1),
+            )
+        }
+
+        it("does not treat a PostgreSQL cast as a named parameter") {
+            QueryParameterParser.parse(
+                "SELECT created_at::text FROM users WHERE status = :status",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.NAMED,
+                names = listOf("status"),
+            )
+        }
+
+        it("rejects dollar quotes that Hibernate cannot parameter-parse") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT \$\$:ignored ?1\$\$ FROM users WHERE status = :status",
+                )
+            }
+        }
+
+        it("keeps embedded dollar tags inside PostgreSQL identifiers") {
+            QueryParameterParser.parse(
+                "SELECT foo\$tag\$bar FROM users WHERE status = :status",
+            ) shouldBe QueryParameters(
+                style = ParameterStyle.NAMED,
+                names = listOf("status"),
+            )
+        }
+
+        it("rejects nested block comments that Hibernate cannot parameter-parse") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT * FROM users /* outer /* :nested */ ?2 */ WHERE status = :status",
+                )
+            }
+        }
+
+        it("rejects an unmatched block-comment terminator") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT * FROM users */ WHERE status = :status",
+                )
+            }
+        }
+
+        it("rejects line comments that do not have consistent Hibernate parser semantics") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.x--e.y > :min",
+                )
+            }
+        }
+
+        it("rejects an unterminated dollar quote") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse("SELECT \$body\$:ignored FROM users")
+            }
+        }
+
+        it("rejects mixed parameter styles") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.first = :first AND e.second = ?2",
+                )
+            }
+        }
+
+        it("rejects non-contiguous positional labels") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.second = ?2",
+                )
+            }
+        }
+
+        it("rejects unlabeled positional parameters") {
+            shouldThrow<IllegalStateException> {
+                QueryParameterParser.parse(
+                    "SELECT e FROM User e WHERE e.id = ?",
+                )
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary

- derive count HQL only for simple entity `SELECT`/`FROM` page queries
- preserve `DISTINCT` entity semantics and remove safe top-level `ORDER BY`
- fail fast for joins, projections, grouping, set operations, trailing selects, query pagination, malformed input, and parameterized ordering
- parse and bind count-query parameters independently so order-only or pagination-only arguments are not sent to the count query
- keep Spring Boot 3 and 4 implementations/tests in parity and document the explicit `countQuery` boundary in English and Korean

## Compatibility

Automatic derivation supports simple entity-alias queries such as `SELECT e FROM Entity e ...`, `SELECT DISTINCT e FROM Entity e ...`, and `FROM Entity e ...`. Complex JPQL page queries and all native page queries require an explicit `countQuery`. Blank count overrides are treated as absent.

## Verification

- Boot 3 full suite: 384 tests, 0 failures
- Boot 4 full suite: 359 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 changed production and test sources: byte-identical
- public `PreparedQueryMethod` JVM constructor/data-class ABI: preserved against `main`
- exact-SHA runtime/debugging audit: passed
- exact-SHA standards review: passed
- exact-SHA specification review: passed
