### PR TITLE
fix: honor modifying query contracts

### DIFF
--- a/docs/migration.ko.md
+++ b/docs/migration.ko.md
@@ -19,7 +19,7 @@ Spring Data JPA에서 Hibernate Reactive Coroutines로 전환하는 가이드입
 | 비교 연산                            |  ✅  | GreaterThan, LessThan, Between 등                     |
 | `@Query` (JPQL)                      |  ✅  | Named/Positional Parameter                            |
 | `@Query` (Native)                    |  ✅  | 읽기만 지원, Page는 `countQuery` 필요                 |
-| `@Modifying`                         |  ✅  | JPQL UPDATE/DELETE                                    |
+| `@Modifying`                         |  ✅  | JPQL UPDATE/DELETE, `Int`/`Unit`, 선택적 자동 clear   |
 | 페이지네이션 (`Page`, `Slice`)       |  ✅  | 스마트 COUNT 스킵 최적화                              |
 
 `Page`를 반환하는 HQL/JPQL `@Query` 메서드는 단순 엔티티 `SELECT`/`FROM` 쿼리만 COUNT를 자동

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -21,7 +21,7 @@ A guide for migrating from Spring Data JPA to Hibernate Reactive Coroutines.
 | Comparison operators                 |     ✅     | GreaterThan, LessThan, Between, etc.                     |
 | `@Query` (JPQL)                      |     ✅     | Named/Positional Parameters                              |
 | `@Query` (Native)                    |     ✅     | Read-only; Page requires `countQuery`                    |
-| `@Modifying`                         |     ✅     | JPQL UPDATE/DELETE                                       |
+| `@Modifying`                         |     ✅     | JPQL UPDATE/DELETE; `Int`/`Unit`, optional auto-clear    |
 | Pagination (`Page`, `Slice`)         |     ✅     | Smart COUNT skip optimization                            |
 
 HQL/JPQL `@Query` methods returning `Page` derive COUNT automatically only for simple entity

--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -143,6 +143,11 @@ interface UserRepository : CoroutineCrudRepository<User, Long> {
 }
 ```
 
+`@Modifying` 메서드는 영향받은 행 수를 받는 `Int` 또는 결과를 노출하지 않는 `Unit`을
+반환해야 합니다. 벌크 업데이트는 이미 관리 중인 엔티티를 동기화하지 않습니다.
+같은 트랜잭션의 후속 조회에서 현재 세션 캐시를 비우고 DB 결과를 읽어야 한다면
+`@Modifying(clearAutomatically = true)`를 사용하세요.
+
 ### 페이지네이션
 
 ```kotlin

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -145,6 +145,11 @@ interface UserRepository : CoroutineCrudRepository<User, Long> {
 }
 ```
 
+`@Modifying` methods must return either `Int` (the affected row count) or `Unit`.
+Bulk updates do not synchronize already managed entities. Use
+`@Modifying(clearAutomatically = true)` when subsequent reads in the same transaction must
+discard the current session cache and observe the database result.
+
 ### Pagination
 
 ```kotlin

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
@@ -137,11 +137,26 @@ internal class QueryMethodParser(
 
     private fun determineAnnotatedReturnType(method: Method, isModifying: Boolean): QueryReturnType {
         return when {
-            isModifying -> QueryReturnType.MODIFYING
+            isModifying -> determineModifyingReturnType(method)
             isPageReturnType(method) -> QueryReturnType.PAGE
             isSliceReturnType(method) -> QueryReturnType.SLICE
             isListReturnType(method) -> QueryReturnType.LIST
             else -> QueryReturnType.SINGLE
+        }
+    }
+
+    private fun determineModifyingReturnType(method: Method): QueryReturnType {
+        val actualReturnType = extractActualReturnType(method)
+        return when {
+            actualReturnType != null &&
+                    isAssignableToRawType(actualReturnType, Int::class.javaObjectType) -> QueryReturnType.MODIFYING
+
+            actualReturnType != null &&
+                    isAssignableToRawType(actualReturnType, Unit::class.java) -> QueryReturnType.VOID
+
+            else -> throw IllegalStateException(
+                "@Modifying method '${method.name}' must return Int or Unit",
+            )
         }
     }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
@@ -1,5 +1,6 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Modifying
 import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
 import io.clroot.hibernate.reactive.spring.boot.repository.query.PreparedQueryMethod
 import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryConstants.ORDER_BY_REGEX
@@ -96,10 +97,19 @@ internal class QueryOperations<T : Any>(
             )
         }
 
+        val clearAutomatically = prepared.method
+            .getAnnotation(Modifying::class.java)
+            ?.clearAutomatically == true
+
         return sessionProvider.write { session ->
             val query = session.createMutationQuery(prepared.hql)
             bindAnnotatedParameters(query, prepared, args)
-            query.executeUpdate()
+            query.executeUpdate().map { affectedRows ->
+                if (clearAutomatically) {
+                    session.clear()
+                }
+                affectedRows
+            }
         }
     }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
@@ -231,6 +231,10 @@ class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
     ): Any? {
         return when (prepared.returnType) {
             QueryReturnType.MODIFYING -> query.executeModifyingAnnotatedQuery(prepared, args)
+            QueryReturnType.VOID -> {
+                query.executeModifyingAnnotatedQuery(prepared, args)
+                Unit
+            }
             QueryReturnType.PAGE -> pagination.executePageAnnotatedQuery(prepared, args, pageable!!)
             QueryReturnType.SLICE -> pagination.executeSliceAnnotatedQuery(prepared, args, pageable!!)
             QueryReturnType.LIST -> query.executeListAnnotatedQuery(prepared, args)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying.kt
@@ -2,8 +2,12 @@ package io.clroot.hibernate.reactive.spring.boot.repository.query
 
 /**
  * UPDATE/DELETE 쿼리임을 표시합니다.
- * @Query와 함께 사용하며, 반환 타입은 Int (영향받은 행 수)입니다.
+ * @Query와 함께 사용하며, 반환 타입은 Int (영향받은 행 수) 또는 Unit입니다.
+ *
+ * @param clearAutomatically 쿼리 실행 후 현재 세션의 영속성 컨텍스트를 비울지 여부
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Modifying
+annotation class Modifying(
+    val clearAutomatically: Boolean = false,
+)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
@@ -1,8 +1,10 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
-import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Modifying
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Param
+import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryReturnType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -120,6 +122,20 @@ class QueryMethodParserTest : DescribeSpec({
             error.message shouldContain "not used by the content query"
         }
     }
+
+    describe("@Modifying return types") {
+        it("accepts Unit and preserves its declared return contract") {
+            parse("deactivate").returnType shouldBe QueryReturnType.VOID
+        }
+
+        it("rejects unsupported return types during repository initialization") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("deactivateWithMessage")
+            }
+
+            error.message shouldContain "must return Int or Unit"
+        }
+    }
 })
 
 private data class User(
@@ -129,6 +145,14 @@ private data class User(
 )
 
 private interface QueryRepository {
+    @Modifying
+    @Query("UPDATE User e SET e.active = false WHERE e.id = :id")
+    suspend fun deactivate(id: Long)
+
+    @Modifying
+    @Query("UPDATE User e SET e.active = false WHERE e.id = :id")
+    suspend fun deactivateWithMessage(id: Long): String
+
     @Query(
         """
         SELECT e FROM User e WHERE e.active = true

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/QueryAnnotationIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/QueryAnnotationIntegrationTest.kt
@@ -131,6 +131,33 @@ class QueryAnnotationIntegrationTest : IntegrationTestBase() {
                     }
                     updated shouldHaveSize 2
                 }
+
+                it("Unit 반환 메서드는 영향받은 행 수를 노출하지 않고 정상 완료한다") {
+                    val uniqueValue = valueCounter.incrementAndGet()
+                    val newValue = uniqueValue + 50
+
+                    tx.transactional {
+                        testEntityRepository.save(TestEntity(name = "unit_update", value = uniqueValue))
+                        testEntityRepository.updateValueWithoutCount(uniqueValue, newValue)
+                    }
+
+                    val updated = tx.readOnly {
+                        testEntityRepository.findByValueWithQuery(newValue)
+                    }
+                    updated shouldHaveSize 1
+                }
+
+                it("clearAutomatically는 벌크 업데이트 뒤 같은 트랜잭션의 stale 엔티티를 제거한다") {
+                    tx.transactional {
+                        val saved = testEntityRepository.save(TestEntity(name = "before_clear", value = 1))
+                        val id = saved.id!!
+                        testEntityRepository.findById(id)!!.name shouldBe "before_clear"
+
+                        testEntityRepository.updateNameAndClear(id, "after_clear") shouldBe 1
+
+                        testEntityRepository.findById(id)!!.name shouldBe "after_clear"
+                    }
+                }
             }
 
             context("@Modifying DELETE") {

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
@@ -78,6 +78,14 @@ interface TestEntityRepository : CoroutineCrudRepository<TestEntity, Long> {
     @Query("UPDATE TestEntity e SET e.value = :newValue WHERE e.value = :oldValue")
     suspend fun updateValue(@Param("oldValue") oldValue: Int, @Param("newValue") newValue: Int): Int
 
+    @Modifying
+    @Query("UPDATE TestEntity e SET e.value = :newValue WHERE e.value = :oldValue")
+    suspend fun updateValueWithoutCount(@Param("oldValue") oldValue: Int, @Param("newValue") newValue: Int)
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE TestEntity e SET e.name = :name WHERE e.id = :id")
+    suspend fun updateNameAndClear(@Param("id") id: Long, @Param("name") name: String): Int
+
     // @Modifying DELETE
     @Modifying
     @Query("DELETE FROM TestEntity e WHERE e.value = :value")

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
@@ -137,11 +137,26 @@ internal class QueryMethodParser(
 
     private fun determineAnnotatedReturnType(method: Method, isModifying: Boolean): QueryReturnType {
         return when {
-            isModifying -> QueryReturnType.MODIFYING
+            isModifying -> determineModifyingReturnType(method)
             isPageReturnType(method) -> QueryReturnType.PAGE
             isSliceReturnType(method) -> QueryReturnType.SLICE
             isListReturnType(method) -> QueryReturnType.LIST
             else -> QueryReturnType.SINGLE
+        }
+    }
+
+    private fun determineModifyingReturnType(method: Method): QueryReturnType {
+        val actualReturnType = extractActualReturnType(method)
+        return when {
+            actualReturnType != null &&
+                    isAssignableToRawType(actualReturnType, Int::class.javaObjectType) -> QueryReturnType.MODIFYING
+
+            actualReturnType != null &&
+                    isAssignableToRawType(actualReturnType, Unit::class.java) -> QueryReturnType.VOID
+
+            else -> throw IllegalStateException(
+                "@Modifying method '${method.name}' must return Int or Unit",
+            )
         }
     }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
@@ -1,5 +1,6 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Modifying
 import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
 import io.clroot.hibernate.reactive.spring.boot.repository.query.PreparedQueryMethod
 import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryConstants.ORDER_BY_REGEX
@@ -96,10 +97,19 @@ internal class QueryOperations<T : Any>(
             )
         }
 
+        val clearAutomatically = prepared.method
+            .getAnnotation(Modifying::class.java)
+            ?.clearAutomatically == true
+
         return sessionProvider.write { session ->
             val query = session.createMutationQuery(prepared.hql)
             bindAnnotatedParameters(query, prepared, args)
-            query.executeUpdate()
+            query.executeUpdate().map { affectedRows ->
+                if (clearAutomatically) {
+                    session.clear()
+                }
+                affectedRows
+            }
         }
     }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
@@ -231,6 +231,10 @@ class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
     ): Any? {
         return when (prepared.returnType) {
             QueryReturnType.MODIFYING -> query.executeModifyingAnnotatedQuery(prepared, args)
+            QueryReturnType.VOID -> {
+                query.executeModifyingAnnotatedQuery(prepared, args)
+                Unit
+            }
             QueryReturnType.PAGE -> pagination.executePageAnnotatedQuery(prepared, args, pageable!!)
             QueryReturnType.SLICE -> pagination.executeSliceAnnotatedQuery(prepared, args, pageable!!)
             QueryReturnType.LIST -> query.executeListAnnotatedQuery(prepared, args)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying.kt
@@ -2,8 +2,12 @@ package io.clroot.hibernate.reactive.spring.boot.repository.query
 
 /**
  * UPDATE/DELETE 쿼리임을 표시합니다.
- * @Query와 함께 사용하며, 반환 타입은 Int (영향받은 행 수)입니다.
+ * @Query와 함께 사용하며, 반환 타입은 Int (영향받은 행 수) 또는 Unit입니다.
+ *
+ * @param clearAutomatically 쿼리 실행 후 현재 세션의 영속성 컨텍스트를 비울지 여부
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Modifying
+annotation class Modifying(
+    val clearAutomatically: Boolean = false,
+)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
@@ -1,8 +1,10 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
-import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Modifying
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Param
+import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryReturnType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -120,6 +122,20 @@ class QueryMethodParserTest : DescribeSpec({
             error.message shouldContain "not used by the content query"
         }
     }
+
+    describe("@Modifying return types") {
+        it("accepts Unit and preserves its declared return contract") {
+            parse("deactivate").returnType shouldBe QueryReturnType.VOID
+        }
+
+        it("rejects unsupported return types during repository initialization") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("deactivateWithMessage")
+            }
+
+            error.message shouldContain "must return Int or Unit"
+        }
+    }
 })
 
 private data class User(
@@ -129,6 +145,14 @@ private data class User(
 )
 
 private interface QueryRepository {
+    @Modifying
+    @Query("UPDATE User e SET e.active = false WHERE e.id = :id")
+    suspend fun deactivate(id: Long)
+
+    @Modifying
+    @Query("UPDATE User e SET e.active = false WHERE e.id = :id")
+    suspend fun deactivateWithMessage(id: Long): String
+
     @Query(
         """
         SELECT e FROM User e WHERE e.active = true

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/QueryAnnotationIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/QueryAnnotationIntegrationTest.kt
@@ -131,6 +131,33 @@ class QueryAnnotationIntegrationTest : IntegrationTestBase() {
                     }
                     updated shouldHaveSize 2
                 }
+
+                it("Unit 반환 메서드는 영향받은 행 수를 노출하지 않고 정상 완료한다") {
+                    val uniqueValue = valueCounter.incrementAndGet()
+                    val newValue = uniqueValue + 50
+
+                    tx.transactional {
+                        testEntityRepository.save(TestEntity(name = "unit_update", value = uniqueValue))
+                        testEntityRepository.updateValueWithoutCount(uniqueValue, newValue)
+                    }
+
+                    val updated = tx.readOnly {
+                        testEntityRepository.findByValueWithQuery(newValue)
+                    }
+                    updated shouldHaveSize 1
+                }
+
+                it("clearAutomatically는 벌크 업데이트 뒤 같은 트랜잭션의 stale 엔티티를 제거한다") {
+                    tx.transactional {
+                        val saved = testEntityRepository.save(TestEntity(name = "before_clear", value = 1))
+                        val id = saved.id!!
+                        testEntityRepository.findById(id)!!.name shouldBe "before_clear"
+
+                        testEntityRepository.updateNameAndClear(id, "after_clear") shouldBe 1
+
+                        testEntityRepository.findById(id)!!.name shouldBe "after_clear"
+                    }
+                }
             }
 
             context("@Modifying DELETE") {

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
@@ -78,6 +78,14 @@ interface TestEntityRepository : CoroutineCrudRepository<TestEntity, Long> {
     @Query("UPDATE TestEntity e SET e.value = :newValue WHERE e.value = :oldValue")
     suspend fun updateValue(@Param("oldValue") oldValue: Int, @Param("newValue") newValue: Int): Int
 
+    @Modifying
+    @Query("UPDATE TestEntity e SET e.value = :newValue WHERE e.value = :oldValue")
+    suspend fun updateValueWithoutCount(@Param("oldValue") oldValue: Int, @Param("newValue") newValue: Int)
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE TestEntity e SET e.name = :name WHERE e.id = :id")
+    suspend fun updateNameAndClear(@Param("id") id: Long, @Param("name") name: String): Int
+
     // @Modifying DELETE
     @Modifying
     @Query("DELETE FROM TestEntity e WHERE e.value = :value")


### PR DESCRIPTION
## Summary

- honor `@Modifying` methods declared with either `Int` or `Unit`
- reject unsupported modifying return types during repository initialization
- add `clearAutomatically` so bulk mutations can discard stale managed entities
- keep the default non-clearing behavior for compatibility
- keep Spring Boot 3 and 4 implementations/tests in parity and document the contract in English and Korean

## Compatibility

Existing `@Modifying` methods returning `Int` retain their affected-row result. The new
`clearAutomatically` annotation member defaults to `false`, so existing session behavior is
unchanged unless explicitly enabled. Native modifying queries remain unsupported.

## Verification

- Boot 3 full suite: 388 tests, 0 failures
- Boot 4 full suite: 363 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 changed production and test sources: byte-identical
- `PreparedQueryMethod` public constructor/data-class ABI: unchanged
- exact-SHA standards review: passed
- exact-SHA specification review: passed
