### PR TITLE
fix: persist new repository entities

### DIFF
--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -84,6 +84,10 @@ interface UserRepository : CoroutineCrudRepository<User, Long>
 | `deleteAllById(ids)` | `Unit`    | 여러 ID로 삭제   |
 | `deleteAll()`        | `Unit`    | 전체 삭제        |
 
+`save`는 신규 엔티티를 전달받은 동일 인스턴스로 persist하므로 생성된 ID가 인자와 반환값에
+모두 반영됩니다. 기존 또는 detached 엔티티는 merge하므로 이후 작업에서는 `save`가 반환한
+인스턴스를 사용하세요.
+
 ### 쿼리 메서드 자동 생성
 
 메서드 이름 기반으로 쿼리가 자동 생성됩니다.

--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -86,7 +86,8 @@ interface UserRepository : CoroutineCrudRepository<User, Long>
 
 `save`는 신규 엔티티를 전달받은 동일 인스턴스로 persist하므로 생성된 ID가 인자와 반환값에
 모두 반영됩니다. 기존 또는 detached 엔티티는 merge하므로 이후 작업에서는 `save`가 반환한
-인스턴스를 사용하세요.
+인스턴스를 사용하세요. 할당형 ID를 쓰는 엔티티는 Spring Data의 `Persistable`을 구현해
+신규 상태를 명시할 수 있습니다.
 
 ### 쿼리 메서드 자동 생성
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -88,7 +88,8 @@ interface UserRepository : CoroutineCrudRepository<User, Long>
 
 `save` persists a new entity as the same managed instance, so a generated identifier is visible
 on both the argument and the returned value. Existing or detached entities are merged; keep using
-the instance returned by `save` for subsequent work.
+the instance returned by `save` for subsequent work. Entities with assigned identifiers can
+implement Spring Data's `Persistable` to declare their new-state explicitly.
 
 ### Query Method Derivation
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -86,6 +86,10 @@ interface UserRepository : CoroutineCrudRepository<User, Long>
 | `deleteAllById(ids)` | `Unit`      | Delete by multiple IDs |
 | `deleteAll()`        | `Unit`      | Delete all           |
 
+`save` persists a new entity as the same managed instance, so a generated identifier is visible
+on both the argument and the returned value. Existing or detached entities are merged; keep using
+the instance returned by `save` for subsequent work.
+
 ### Query Method Derivation
 
 Queries are automatically generated based on method names.

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
@@ -7,7 +7,6 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
-import org.springframework.data.domain.Persistable
 import java.lang.reflect.Field
 import java.time.Instant
 import java.time.LocalDateTime
@@ -33,37 +32,6 @@ internal object AuditMetadata {
         return cache.computeIfAbsent(entityClass) { cls ->
             extractAuditInfo(cls)
         }
-    }
-
-    /**
-     * 엔티티가 신규인지 판단합니다.
-     *
-     * 판단 순서:
-     * 1. Persistable 인터페이스 구현 시 isNew() 호출
-     * 2. @Version 필드가 있고 null이거나 0이면 신규
-     * 3. @Id 필드가 null이면 신규
-     */
-    fun isNew(entity: Any): Boolean {
-        // 1. Persistable 인터페이스 확인
-        if (entity is Persistable<*>) {
-            return entity.isNew
-        }
-
-        val auditInfo = getAuditInfo(entity.javaClass)
-
-        // 2. @Version 필드 확인
-        auditInfo.versionField?.let { field ->
-            val value = getFieldValueSafely(entity, field)
-            return value == null || (value is Number && value.toLong() == 0L)
-        }
-
-        // 3. @Id 필드 확인
-        auditInfo.idField?.let { field ->
-            return getFieldValueSafely(entity, field) == null
-        }
-
-        // 판단 불가 시 신규로 간주
-        return true
     }
 
     /**

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -31,8 +31,8 @@ internal class CrudOperations<T : Any, ID : Any>(
     // ============================================
 
     suspend fun save(entity: T): T {
+        val isNew = AuditMetadata.isNew(entity)
         if (auditingHandler != null) {
-            val isNew = AuditMetadata.isNew(entity)
             if (isNew) {
                 auditingHandler.markCreated(entity)
             } else {
@@ -41,7 +41,11 @@ internal class CrudOperations<T : Any, ID : Any>(
         }
 
         return sessionProvider.write { session ->
-            session.merge(entity)
+            if (isNew) {
+                session.persist(entity).replaceWith(entity)
+            } else {
+                session.merge(entity)
+            }
         }
     }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -1,7 +1,6 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
 import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
-import io.clroot.hibernate.reactive.spring.boot.auditing.AuditMetadata
 import io.clroot.hibernate.reactive.spring.boot.auditing.ReactiveAuditingHandler
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
 import kotlinx.coroutines.flow.Flow
@@ -31,7 +30,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     // ============================================
 
     suspend fun save(entity: T): T {
-        val isNew = AuditMetadata.isNew(entity)
+        val isNew = EntityStateDetector.isNew(entity)
         if (auditingHandler != null) {
             if (isNew) {
                 auditingHandler.markCreated(entity)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetector.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetector.kt
@@ -1,0 +1,131 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Id
+import jakarta.persistence.Version
+import org.springframework.data.domain.Persistable
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Determines whether a repository entity should be persisted or merged.
+ *
+ * The rules follow Spring Data's default new-state semantics:
+ * [Persistable] takes precedence, a nullable version is used when present,
+ * and otherwise null or primitive-default identifiers represent a new entity.
+ */
+internal object EntityStateDetector {
+    private val cache = ConcurrentHashMap<Class<*>, EntityStateMetadata>()
+
+    fun isNew(entity: Any): Boolean {
+        if (entity is Persistable<*>) {
+            return entity.isNew
+        }
+
+        return cache.computeIfAbsent(entity.javaClass, ::inspect).isNew(entity)
+    }
+
+    private fun inspect(entityClass: Class<*>): EntityStateMetadata {
+        val identifiers = mutableListOf<ValueAccessor>()
+        var version: ValueAccessor? = null
+        var currentClass: Class<*>? = entityClass
+
+        while (currentClass != null && currentClass != Any::class.java) {
+            currentClass.declaredFields.forEach { field ->
+                when {
+                    field.isAnnotationPresent(Version::class.java) && version == null -> {
+                        version = FieldAccessor(field)
+                    }
+
+                    field.isIdentifier() -> identifiers += FieldAccessor(field)
+                }
+            }
+            currentClass.declaredMethods
+                .filter { it.parameterCount == 0 }
+                .forEach { method ->
+                    when {
+                        method.isAnnotationPresent(Version::class.java) && version == null -> {
+                            version = MethodAccessor(method)
+                        }
+
+                        method.isIdentifier() -> identifiers += MethodAccessor(method)
+                    }
+                }
+            currentClass = currentClass.superclass
+        }
+
+        check(identifiers.isNotEmpty()) {
+            "Cannot determine whether ${entityClass.name} is new because it has no " +
+                    "@Id or @EmbeddedId field/getter"
+        }
+
+        return EntityStateMetadata(identifiers, version)
+    }
+
+    private fun Field.isIdentifier(): Boolean =
+        isAnnotationPresent(Id::class.java) || isAnnotationPresent(EmbeddedId::class.java)
+
+    private fun Method.isIdentifier(): Boolean =
+        isAnnotationPresent(Id::class.java) || isAnnotationPresent(EmbeddedId::class.java)
+
+    private data class EntityStateMetadata(
+        val identifiers: List<ValueAccessor>,
+        val version: ValueAccessor?,
+    ) {
+        fun isNew(entity: Any): Boolean {
+            version
+                ?.takeUnless { it.javaType.isPrimitive }
+                ?.let { return it.read(entity) == null }
+
+            return identifiers.any { identifier ->
+                val value = identifier.read(entity)
+                value == null || identifier.javaType.isPrimitiveDefault(value)
+            }
+        }
+    }
+
+    private sealed interface ValueAccessor {
+        val javaType: Class<*>
+
+        fun read(entity: Any): Any?
+    }
+
+    private class FieldAccessor(
+        private val field: Field,
+    ) : ValueAccessor {
+        init {
+            check(field.trySetAccessible()) {
+                "Cannot access persistent field ${field.declaringClass.name}.${field.name}"
+            }
+        }
+
+        override val javaType: Class<*> = field.type
+
+        override fun read(entity: Any): Any? = field.get(entity)
+    }
+
+    private class MethodAccessor(
+        private val method: Method,
+    ) : ValueAccessor {
+        init {
+            check(method.trySetAccessible()) {
+                "Cannot access persistent getter ${method.declaringClass.name}.${method.name}"
+            }
+        }
+
+        override val javaType: Class<*> = method.returnType
+
+        override fun read(entity: Any): Any? = method.invoke(entity)
+    }
+
+    private fun Class<*>.isPrimitiveDefault(value: Any): Boolean {
+        if (!isPrimitive) return false
+        return when (value) {
+            is Number -> value.toDouble() == 0.0
+            is Char -> value == '\u0000'
+            is Boolean -> !value
+            else -> false
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetectorTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetectorTest.kt
@@ -1,0 +1,91 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Id
+import jakarta.persistence.Version
+import org.springframework.data.domain.Persistable
+
+class EntityStateDetectorTest : DescribeSpec({
+    describe("repository entity state") {
+        it("treats a primitive zero identifier as new") {
+            EntityStateDetector.isNew(PrimitiveIdEntity()).shouldBeTrue()
+            EntityStateDetector.isNew(PrimitiveIdEntity(1L)).shouldBeFalse()
+        }
+
+        it("treats only a null nullable version as new when a version is available") {
+            EntityStateDetector.isNew(VersionedEntity(id = 1L, version = null)).shouldBeTrue()
+            EntityStateDetector.isNew(VersionedEntity(id = 1L, version = 0L)).shouldBeFalse()
+        }
+
+        it("reads identifiers from property-access getters") {
+            EntityStateDetector.isNew(PropertyAccessEntity(null)).shouldBeTrue()
+            EntityStateDetector.isNew(PropertyAccessEntity(1L)).shouldBeFalse()
+        }
+
+        it("reads embedded identifiers") {
+            EntityStateDetector.isNew(EmbeddedIdEntity(null)).shouldBeTrue()
+            EntityStateDetector.isNew(EmbeddedIdEntity(ExampleId(1L))).shouldBeFalse()
+        }
+
+        it("reads inherited identifiers") {
+            EntityStateDetector.isNew(InheritedIdEntity(null)).shouldBeTrue()
+            EntityStateDetector.isNew(InheritedIdEntity(1L)).shouldBeFalse()
+        }
+
+        it("honors Persistable overrides") {
+            EntityStateDetector.isNew(PersistableEntity(newState = true)).shouldBeTrue()
+            EntityStateDetector.isNew(PersistableEntity(newState = false)).shouldBeFalse()
+        }
+    }
+})
+
+private class PrimitiveIdEntity(
+    @field:Id
+    var id: Long = 0,
+)
+
+private class VersionedEntity(
+    @field:Id
+    var id: Long?,
+    @field:Version
+    var version: Long?,
+)
+
+private class PropertyAccessEntity(
+    private val identifier: Long?,
+) {
+    @get:Id
+    val id: Long?
+        get() = identifier
+}
+
+@Embeddable
+private data class ExampleId(
+    val value: Long,
+)
+
+private class EmbeddedIdEntity(
+    @field:EmbeddedId
+    var id: ExampleId?,
+)
+
+private open class IdBase(
+    @field:Id
+    var id: Long?,
+)
+
+private class InheritedIdEntity(
+    id: Long?,
+) : IdBase(id)
+
+private class PersistableEntity(
+    private val newState: Boolean,
+) : Persistable<Long> {
+    override fun getId(): Long? = 1L
+
+    override fun isNew(): Boolean = newState
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/JpaSpecCompatibilityTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/JpaSpecCompatibilityTest.kt
@@ -135,6 +135,18 @@ class JpaSpecCompatibilityTest : IntegrationTestBase() {
                     // Then: 버전 증가
                     updated.version shouldBe 1L
                 }
+
+                it("초기 버전 0인 detached 엔티티는 merge하여 업데이트한다") {
+                    val detached = jpaSpecTestService.saveVersionedEntity("detached-version-zero", 100)
+                    detached.version shouldBe 0L
+                    detached.name = "detached-updated"
+
+                    val updated = jpaSpecTestService.saveVersionedEntity(detached)
+
+                    updated.id shouldBe detached.id
+                    updated.name shouldBe "detached-updated"
+                    updated.version shouldBe 1L
+                }
             }
 
             context("동시에 같은 엔티티를 수정하면") {

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
@@ -45,6 +45,18 @@ class ReactiveRepositoryIntegrationTest : IntegrationTestBase() {
                     entity.id.shouldNotBeNull()
                 }
 
+                it("saveAll도 신규 엔티티 인스턴스를 그대로 persist한다") {
+                    val entities = listOf(
+                        TestEntity(name = "persistAll1", value = 102),
+                        TestEntity(name = "persistAll2", value = 103),
+                    )
+
+                    val saved = testEntityRepository.saveAll(entities).toList()
+
+                    saved shouldBe entities
+                    entities.forEach { it.id.shouldNotBeNull() }
+                }
+
                 it("기존 엔티티를 업데이트한다") {
                     // given
                     val entity = TestEntity(name = "updateTest", value = 50)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
@@ -34,6 +34,17 @@ class ReactiveRepositoryIntegrationTest : IntegrationTestBase() {
                     saved.value shouldBe 100
                 }
 
+                it("신규 엔티티는 전달한 인스턴스가 관리되고 생성된 ID도 같은 인스턴스에 반영된다") {
+                    val entity = TestEntity(name = "persistNew", value = 101)
+
+                    val saved = tx.transactional {
+                        testEntityRepository.save(entity)
+                    }
+
+                    saved shouldBe entity
+                    entity.id.shouldNotBeNull()
+                }
+
                 it("기존 엔티티를 업데이트한다") {
                     // given
                     val entity = TestEntity(name = "updateTest", value = 50)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/JpaSpecTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/JpaSpecTestService.kt
@@ -110,6 +110,11 @@ class JpaSpecTestService(
     }
 
     @Transactional
+    suspend fun saveVersionedEntity(entity: VersionedEntity): VersionedEntity {
+        return versionedEntityRepository.save(entity)
+    }
+
+    @Transactional
     suspend fun updateVersionedEntity(id: Long, newName: String, newValue: Int): VersionedEntity {
         val entity = versionedEntityRepository.findById(id)!!
         entity.name = newName

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
@@ -7,7 +7,6 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
-import org.springframework.data.domain.Persistable
 import java.lang.reflect.Field
 import java.time.Instant
 import java.time.LocalDateTime
@@ -33,37 +32,6 @@ internal object AuditMetadata {
         return cache.computeIfAbsent(entityClass) { cls ->
             extractAuditInfo(cls)
         }
-    }
-
-    /**
-     * 엔티티가 신규인지 판단합니다.
-     *
-     * 판단 순서:
-     * 1. Persistable 인터페이스 구현 시 isNew() 호출
-     * 2. @Version 필드가 있고 null이거나 0이면 신규
-     * 3. @Id 필드가 null이면 신규
-     */
-    fun isNew(entity: Any): Boolean {
-        // 1. Persistable 인터페이스 확인
-        if (entity is Persistable<*>) {
-            return entity.isNew
-        }
-
-        val auditInfo = getAuditInfo(entity.javaClass)
-
-        // 2. @Version 필드 확인
-        auditInfo.versionField?.let { field ->
-            val value = getFieldValueSafely(entity, field)
-            return value == null || (value is Number && value.toLong() == 0L)
-        }
-
-        // 3. @Id 필드 확인
-        auditInfo.idField?.let { field ->
-            return getFieldValueSafely(entity, field) == null
-        }
-
-        // 판단 불가 시 신규로 간주
-        return true
     }
 
     /**

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -31,8 +31,8 @@ internal class CrudOperations<T : Any, ID : Any>(
     // ============================================
 
     suspend fun save(entity: T): T {
+        val isNew = AuditMetadata.isNew(entity)
         if (auditingHandler != null) {
-            val isNew = AuditMetadata.isNew(entity)
             if (isNew) {
                 auditingHandler.markCreated(entity)
             } else {
@@ -41,7 +41,11 @@ internal class CrudOperations<T : Any, ID : Any>(
         }
 
         return sessionProvider.write { session ->
-            session.merge(entity)
+            if (isNew) {
+                session.persist(entity).replaceWith(entity)
+            } else {
+                session.merge(entity)
+            }
         }
     }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -1,7 +1,6 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
 import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
-import io.clroot.hibernate.reactive.spring.boot.auditing.AuditMetadata
 import io.clroot.hibernate.reactive.spring.boot.auditing.ReactiveAuditingHandler
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
 import kotlinx.coroutines.flow.Flow
@@ -31,7 +30,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     // ============================================
 
     suspend fun save(entity: T): T {
-        val isNew = AuditMetadata.isNew(entity)
+        val isNew = EntityStateDetector.isNew(entity)
         if (auditingHandler != null) {
             if (isNew) {
                 auditingHandler.markCreated(entity)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetector.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetector.kt
@@ -1,0 +1,131 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Id
+import jakarta.persistence.Version
+import org.springframework.data.domain.Persistable
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Determines whether a repository entity should be persisted or merged.
+ *
+ * The rules follow Spring Data's default new-state semantics:
+ * [Persistable] takes precedence, a nullable version is used when present,
+ * and otherwise null or primitive-default identifiers represent a new entity.
+ */
+internal object EntityStateDetector {
+    private val cache = ConcurrentHashMap<Class<*>, EntityStateMetadata>()
+
+    fun isNew(entity: Any): Boolean {
+        if (entity is Persistable<*>) {
+            return entity.isNew
+        }
+
+        return cache.computeIfAbsent(entity.javaClass, ::inspect).isNew(entity)
+    }
+
+    private fun inspect(entityClass: Class<*>): EntityStateMetadata {
+        val identifiers = mutableListOf<ValueAccessor>()
+        var version: ValueAccessor? = null
+        var currentClass: Class<*>? = entityClass
+
+        while (currentClass != null && currentClass != Any::class.java) {
+            currentClass.declaredFields.forEach { field ->
+                when {
+                    field.isAnnotationPresent(Version::class.java) && version == null -> {
+                        version = FieldAccessor(field)
+                    }
+
+                    field.isIdentifier() -> identifiers += FieldAccessor(field)
+                }
+            }
+            currentClass.declaredMethods
+                .filter { it.parameterCount == 0 }
+                .forEach { method ->
+                    when {
+                        method.isAnnotationPresent(Version::class.java) && version == null -> {
+                            version = MethodAccessor(method)
+                        }
+
+                        method.isIdentifier() -> identifiers += MethodAccessor(method)
+                    }
+                }
+            currentClass = currentClass.superclass
+        }
+
+        check(identifiers.isNotEmpty()) {
+            "Cannot determine whether ${entityClass.name} is new because it has no " +
+                    "@Id or @EmbeddedId field/getter"
+        }
+
+        return EntityStateMetadata(identifiers, version)
+    }
+
+    private fun Field.isIdentifier(): Boolean =
+        isAnnotationPresent(Id::class.java) || isAnnotationPresent(EmbeddedId::class.java)
+
+    private fun Method.isIdentifier(): Boolean =
+        isAnnotationPresent(Id::class.java) || isAnnotationPresent(EmbeddedId::class.java)
+
+    private data class EntityStateMetadata(
+        val identifiers: List<ValueAccessor>,
+        val version: ValueAccessor?,
+    ) {
+        fun isNew(entity: Any): Boolean {
+            version
+                ?.takeUnless { it.javaType.isPrimitive }
+                ?.let { return it.read(entity) == null }
+
+            return identifiers.any { identifier ->
+                val value = identifier.read(entity)
+                value == null || identifier.javaType.isPrimitiveDefault(value)
+            }
+        }
+    }
+
+    private sealed interface ValueAccessor {
+        val javaType: Class<*>
+
+        fun read(entity: Any): Any?
+    }
+
+    private class FieldAccessor(
+        private val field: Field,
+    ) : ValueAccessor {
+        init {
+            check(field.trySetAccessible()) {
+                "Cannot access persistent field ${field.declaringClass.name}.${field.name}"
+            }
+        }
+
+        override val javaType: Class<*> = field.type
+
+        override fun read(entity: Any): Any? = field.get(entity)
+    }
+
+    private class MethodAccessor(
+        private val method: Method,
+    ) : ValueAccessor {
+        init {
+            check(method.trySetAccessible()) {
+                "Cannot access persistent getter ${method.declaringClass.name}.${method.name}"
+            }
+        }
+
+        override val javaType: Class<*> = method.returnType
+
+        override fun read(entity: Any): Any? = method.invoke(entity)
+    }
+
+    private fun Class<*>.isPrimitiveDefault(value: Any): Boolean {
+        if (!isPrimitive) return false
+        return when (value) {
+            is Number -> value.toDouble() == 0.0
+            is Char -> value == '\u0000'
+            is Boolean -> !value
+            else -> false
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetectorTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EntityStateDetectorTest.kt
@@ -1,0 +1,91 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Id
+import jakarta.persistence.Version
+import org.springframework.data.domain.Persistable
+
+class EntityStateDetectorTest : DescribeSpec({
+    describe("repository entity state") {
+        it("treats a primitive zero identifier as new") {
+            EntityStateDetector.isNew(PrimitiveIdEntity()).shouldBeTrue()
+            EntityStateDetector.isNew(PrimitiveIdEntity(1L)).shouldBeFalse()
+        }
+
+        it("treats only a null nullable version as new when a version is available") {
+            EntityStateDetector.isNew(VersionedEntity(id = 1L, version = null)).shouldBeTrue()
+            EntityStateDetector.isNew(VersionedEntity(id = 1L, version = 0L)).shouldBeFalse()
+        }
+
+        it("reads identifiers from property-access getters") {
+            EntityStateDetector.isNew(PropertyAccessEntity(null)).shouldBeTrue()
+            EntityStateDetector.isNew(PropertyAccessEntity(1L)).shouldBeFalse()
+        }
+
+        it("reads embedded identifiers") {
+            EntityStateDetector.isNew(EmbeddedIdEntity(null)).shouldBeTrue()
+            EntityStateDetector.isNew(EmbeddedIdEntity(ExampleId(1L))).shouldBeFalse()
+        }
+
+        it("reads inherited identifiers") {
+            EntityStateDetector.isNew(InheritedIdEntity(null)).shouldBeTrue()
+            EntityStateDetector.isNew(InheritedIdEntity(1L)).shouldBeFalse()
+        }
+
+        it("honors Persistable overrides") {
+            EntityStateDetector.isNew(PersistableEntity(newState = true)).shouldBeTrue()
+            EntityStateDetector.isNew(PersistableEntity(newState = false)).shouldBeFalse()
+        }
+    }
+})
+
+private class PrimitiveIdEntity(
+    @field:Id
+    var id: Long = 0,
+)
+
+private class VersionedEntity(
+    @field:Id
+    var id: Long?,
+    @field:Version
+    var version: Long?,
+)
+
+private class PropertyAccessEntity(
+    private val identifier: Long?,
+) {
+    @get:Id
+    val id: Long?
+        get() = identifier
+}
+
+@Embeddable
+private data class ExampleId(
+    val value: Long,
+)
+
+private class EmbeddedIdEntity(
+    @field:EmbeddedId
+    var id: ExampleId?,
+)
+
+private open class IdBase(
+    @field:Id
+    var id: Long?,
+)
+
+private class InheritedIdEntity(
+    id: Long?,
+) : IdBase(id)
+
+private class PersistableEntity(
+    private val newState: Boolean,
+) : Persistable<Long> {
+    override fun getId(): Long? = 1L
+
+    override fun isNew(): Boolean = newState
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/JpaSpecCompatibilityTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/JpaSpecCompatibilityTest.kt
@@ -135,6 +135,18 @@ class JpaSpecCompatibilityTest : IntegrationTestBase() {
                     // Then: 버전 증가
                     updated.version shouldBe 1L
                 }
+
+                it("초기 버전 0인 detached 엔티티는 merge하여 업데이트한다") {
+                    val detached = jpaSpecTestService.saveVersionedEntity("detached-version-zero", 100)
+                    detached.version shouldBe 0L
+                    detached.name = "detached-updated"
+
+                    val updated = jpaSpecTestService.saveVersionedEntity(detached)
+
+                    updated.id shouldBe detached.id
+                    updated.name shouldBe "detached-updated"
+                    updated.version shouldBe 1L
+                }
             }
 
             context("동시에 같은 엔티티를 수정하면") {

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
@@ -45,6 +45,18 @@ class ReactiveRepositoryIntegrationTest : IntegrationTestBase() {
                     entity.id.shouldNotBeNull()
                 }
 
+                it("saveAll도 신규 엔티티 인스턴스를 그대로 persist한다") {
+                    val entities = listOf(
+                        TestEntity(name = "persistAll1", value = 102),
+                        TestEntity(name = "persistAll2", value = 103),
+                    )
+
+                    val saved = testEntityRepository.saveAll(entities).toList()
+
+                    saved shouldBe entities
+                    entities.forEach { it.id.shouldNotBeNull() }
+                }
+
                 it("기존 엔티티를 업데이트한다") {
                     // given
                     val entity = TestEntity(name = "updateTest", value = 50)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveRepositoryIntegrationTest.kt
@@ -34,6 +34,17 @@ class ReactiveRepositoryIntegrationTest : IntegrationTestBase() {
                     saved.value shouldBe 100
                 }
 
+                it("신규 엔티티는 전달한 인스턴스가 관리되고 생성된 ID도 같은 인스턴스에 반영된다") {
+                    val entity = TestEntity(name = "persistNew", value = 101)
+
+                    val saved = tx.transactional {
+                        testEntityRepository.save(entity)
+                    }
+
+                    saved shouldBe entity
+                    entity.id.shouldNotBeNull()
+                }
+
                 it("기존 엔티티를 업데이트한다") {
                     // given
                     val entity = TestEntity(name = "updateTest", value = 50)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/JpaSpecTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/JpaSpecTestService.kt
@@ -8,7 +8,6 @@ import io.clroot.hibernate.reactive.test.entity.VersionedEntity
 import io.clroot.hibernate.reactive.test.repository.ParentEntityRepository
 import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
 import io.clroot.hibernate.reactive.test.repository.VersionedEntityRepository
-import io.smallrye.mutiny.coroutines.awaitSuspending
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -111,6 +110,11 @@ class JpaSpecTestService(
     }
 
     @Transactional
+    suspend fun saveVersionedEntity(entity: VersionedEntity): VersionedEntity {
+        return versionedEntityRepository.save(entity)
+    }
+
+    @Transactional
     suspend fun updateVersionedEntity(id: Long, newName: String, newValue: Int): VersionedEntity {
         val entity = versionedEntityRepository.findById(id)!!
         entity.name = newName
@@ -138,7 +142,7 @@ class JpaSpecTestService(
         id: Long,
         newName: String,
         newValue: Int,
-        delayMs: Long
+        delayMs: Long,
     ): VersionedEntity {
         val entity = versionedEntityRepository.findById(id)!!
         delay(delayMs)


### PR DESCRIPTION
## Summary

- persist new repository entities instead of always merging them
- return the same managed instance for new entities so generated identifiers update the caller's object
- retain merge semantics for existing and detached entities
- use the same new-state decision for auditing and persistence
- keep Spring Boot 3 and 4 implementations/tests in parity and document the save contract

## Compatibility

Existing and detached entities continue to use Hibernate `merge`, and callers should use the
returned managed instance. New entities now follow Spring Data-style `persist` semantics; custom
new-state rules through `Persistable` continue to take precedence.

## Verification

- Boot 3 full suite: 397 tests, 0 failures
- Boot 4 full suite: 372 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 changed production and test sources: byte-identical
- exact-SHA standards review: passed
- exact-SHA specification review: passed
