### PR TITLE
fix: unwrap value class repository ids

### DIFF
--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -89,6 +89,9 @@ interface UserRepository : CoroutineCrudRepository<User, Long>
 인스턴스를 사용하세요. 할당형 ID를 쓰는 엔티티는 Spring Data의 `Persistable`을 구현해
 신규 상태를 명시할 수 있습니다.
 
+리포지토리 ID 메서드는 Kotlin `@JvmInline` value class도 지원하며 Hibernate에 전달할 때
+내부 ID 타입으로 변환합니다.
+
 ### 쿼리 메서드 자동 생성
 
 메서드 이름 기반으로 쿼리가 자동 생성됩니다.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -91,6 +91,9 @@ on both the argument and the returned value. Existing or detached entities are m
 the instance returned by `save` for subsequent work. Entities with assigned identifiers can
 implement Spring Data's `Persistable` to declare their new-state explicitly.
 
+Repository ID methods also accept Kotlin `@JvmInline` value classes and unwrap them to the
+underlying Hibernate identifier type.
+
 ### Query Method Derivation
 
 Queries are automatically generated based on method names.

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -68,7 +68,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     // ============================================
 
     suspend fun findById(id: ID): T? = sessionProvider.read { session ->
-        session.find(entityClass, id)
+        session.find(entityClass, RepositoryIdAdapter.unwrap(id))
     }
 
     fun findAll(): Flow<T> = flow {
@@ -79,7 +79,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     }
 
     fun findAllById(ids: Iterable<ID>): Flow<T> = flow {
-        val idList = ids.toList()
+        val idList = ids.map(RepositoryIdAdapter::unwrap)
         if (idList.isEmpty()) return@flow
 
         val list = sessionProvider.read { session ->
@@ -102,7 +102,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     suspend fun existsById(id: ID): Boolean {
         val count = sessionProvider.read { session ->
             session.createQuery("SELECT COUNT(e) FROM $entityName e WHERE e.id = :id", Long::class.javaObjectType)
-                .setParameter("id", id)
+                .setParameter("id", RepositoryIdAdapter.unwrap(id))
                 .singleResult
         }
         return (count ?: 0L) > 0
@@ -120,7 +120,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     suspend fun deleteById(id: ID) {
         sessionProvider.write<Unit> { session ->
             session.createMutationQuery("DELETE FROM $entityName e WHERE e.id = :id")
-                .setParameter("id", id)
+                .setParameter("id", RepositoryIdAdapter.unwrap(id))
                 .executeUpdate()
                 .replaceWith(Unit)
         }
@@ -134,7 +134,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     }
 
     suspend fun deleteAllById(ids: Iterable<ID>) {
-        val idList = ids.toList()
+        val idList = ids.map(RepositoryIdAdapter::unwrap)
         if (idList.isEmpty()) return
 
         sessionProvider.write<Unit> { session ->

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/RepositoryIdAdapter.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/RepositoryIdAdapter.kt
@@ -1,0 +1,49 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.jvm.jvmName
+
+/**
+ * Adapts repository identifier values to the JVM type used by Hibernate.
+ */
+internal object RepositoryIdAdapter {
+    private val adapters = ConcurrentHashMap<Class<*>, IdAdapter>()
+
+    fun unwrap(id: Any): Any {
+        return adapters.computeIfAbsent(id.javaClass, ::createAdapter).unwrap(id)
+    }
+
+    private fun createAdapter(idClass: Class<*>): IdAdapter {
+        if (!idClass.kotlin.isValue) {
+            return IdentityAdapter
+        }
+
+        val unboxMethod = idClass.declaredMethods.singleOrNull {
+            it.name == "unbox-impl" && it.parameterCount == 0
+        } ?: error("Cannot find value class unbox method for ${idClass.kotlin.jvmName}")
+
+        check(unboxMethod.trySetAccessible()) {
+            "Cannot access value class unbox method for ${idClass.kotlin.jvmName}"
+        }
+        return ValueClassAdapter(unboxMethod)
+    }
+
+    private fun interface IdAdapter {
+        fun unwrap(id: Any): Any
+    }
+
+    private object IdentityAdapter : IdAdapter {
+        override fun unwrap(id: Any): Any = id
+    }
+
+    private class ValueClassAdapter(
+        private val unboxMethod: Method,
+    ) : IdAdapter {
+        override fun unwrap(id: Any): Any {
+            return checkNotNull(unboxMethod.invoke(id)) {
+                "Value class identifier ${id.javaClass.name} unboxed to null"
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ValueClassIdIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ValueClassIdIntegrationTest.kt
@@ -1,0 +1,70 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.ValueEntityId
+import io.clroot.hibernate.reactive.test.entity.ValueIdEntity
+import io.clroot.hibernate.reactive.test.repository.ValueIdEntityRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.toList
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.atomic.AtomicLong
+
+@SpringBootTest(classes = [TestApplication::class])
+class ValueClassIdIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var repository: ValueIdEntityRepository
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    private val identifiers = AtomicLong(10_000)
+
+    init {
+        describe("Kotlin value class repository identifiers") {
+            it("finds an entity by its wrapped identifier") {
+                val id = ValueEntityId(identifiers.incrementAndGet())
+                tx.transactional {
+                    repository.save(ValueIdEntity(id, "value-id"))
+                }
+
+                val found = tx.readOnly {
+                    repository.findById(id)
+                }
+
+                found?.id shouldBe id
+                found?.name shouldBe "value-id"
+                repository.existsById(id) shouldBe true
+            }
+
+            it("finds entities by wrapped identifier collections") {
+                val ids = listOf(
+                    ValueEntityId(identifiers.incrementAndGet()),
+                    ValueEntityId(identifiers.incrementAndGet()),
+                )
+                tx.transactional {
+                    ids.forEach { repository.save(ValueIdEntity(it, "value-${it.value}")) }
+                }
+
+                val found = repository.findAllById(ids).toList()
+
+                found.map { it.id }.toSet() shouldBe ids.toSet()
+            }
+
+            it("deletes by wrapped single and collection identifiers") {
+                val first = ValueEntityId(identifiers.incrementAndGet())
+                val second = ValueEntityId(identifiers.incrementAndGet())
+                tx.transactional {
+                    repository.save(ValueIdEntity(first, "delete-single"))
+                    repository.save(ValueIdEntity(second, "delete-collection"))
+                }
+
+                repository.deleteById(first)
+                repository.existsById(first) shouldBe false
+
+                repository.deleteAllById(listOf(second))
+                repository.existsById(second) shouldBe false
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/ValueIdEntity.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/ValueIdEntity.kt
@@ -1,0 +1,18 @@
+package io.clroot.hibernate.reactive.test.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@JvmInline
+value class ValueEntityId(
+    val value: Long,
+)
+
+@Entity
+@Table(name = "value_id_entity")
+class ValueIdEntity(
+    @Id
+    val id: ValueEntityId,
+    var name: String,
+)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ValueIdEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ValueIdEntityRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.test.repository
+
+import io.clroot.hibernate.reactive.test.entity.ValueEntityId
+import io.clroot.hibernate.reactive.test.entity.ValueIdEntity
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ValueIdEntityRepository : CoroutineCrudRepository<ValueIdEntity, ValueEntityId>

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -68,7 +68,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     // ============================================
 
     suspend fun findById(id: ID): T? = sessionProvider.read { session ->
-        session.find(entityClass, id)
+        session.find(entityClass, RepositoryIdAdapter.unwrap(id))
     }
 
     fun findAll(): Flow<T> = flow {
@@ -79,7 +79,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     }
 
     fun findAllById(ids: Iterable<ID>): Flow<T> = flow {
-        val idList = ids.toList()
+        val idList = ids.map(RepositoryIdAdapter::unwrap)
         if (idList.isEmpty()) return@flow
 
         val list = sessionProvider.read { session ->
@@ -102,7 +102,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     suspend fun existsById(id: ID): Boolean {
         val count = sessionProvider.read { session ->
             session.createQuery("SELECT COUNT(e) FROM $entityName e WHERE e.id = :id", Long::class.javaObjectType)
-                .setParameter("id", id)
+                .setParameter("id", RepositoryIdAdapter.unwrap(id))
                 .singleResult
         }
         return (count ?: 0L) > 0
@@ -120,7 +120,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     suspend fun deleteById(id: ID) {
         sessionProvider.write<Unit> { session ->
             session.createMutationQuery("DELETE FROM $entityName e WHERE e.id = :id")
-                .setParameter("id", id)
+                .setParameter("id", RepositoryIdAdapter.unwrap(id))
                 .executeUpdate()
                 .replaceWith(Unit)
         }
@@ -134,7 +134,7 @@ internal class CrudOperations<T : Any, ID : Any>(
     }
 
     suspend fun deleteAllById(ids: Iterable<ID>) {
-        val idList = ids.toList()
+        val idList = ids.map(RepositoryIdAdapter::unwrap)
         if (idList.isEmpty()) return
 
         sessionProvider.write<Unit> { session ->

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/RepositoryIdAdapter.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/RepositoryIdAdapter.kt
@@ -1,0 +1,49 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.jvm.jvmName
+
+/**
+ * Adapts repository identifier values to the JVM type used by Hibernate.
+ */
+internal object RepositoryIdAdapter {
+    private val adapters = ConcurrentHashMap<Class<*>, IdAdapter>()
+
+    fun unwrap(id: Any): Any {
+        return adapters.computeIfAbsent(id.javaClass, ::createAdapter).unwrap(id)
+    }
+
+    private fun createAdapter(idClass: Class<*>): IdAdapter {
+        if (!idClass.kotlin.isValue) {
+            return IdentityAdapter
+        }
+
+        val unboxMethod = idClass.declaredMethods.singleOrNull {
+            it.name == "unbox-impl" && it.parameterCount == 0
+        } ?: error("Cannot find value class unbox method for ${idClass.kotlin.jvmName}")
+
+        check(unboxMethod.trySetAccessible()) {
+            "Cannot access value class unbox method for ${idClass.kotlin.jvmName}"
+        }
+        return ValueClassAdapter(unboxMethod)
+    }
+
+    private fun interface IdAdapter {
+        fun unwrap(id: Any): Any
+    }
+
+    private object IdentityAdapter : IdAdapter {
+        override fun unwrap(id: Any): Any = id
+    }
+
+    private class ValueClassAdapter(
+        private val unboxMethod: Method,
+    ) : IdAdapter {
+        override fun unwrap(id: Any): Any {
+            return checkNotNull(unboxMethod.invoke(id)) {
+                "Value class identifier ${id.javaClass.name} unboxed to null"
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ValueClassIdIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ValueClassIdIntegrationTest.kt
@@ -1,0 +1,70 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.ValueEntityId
+import io.clroot.hibernate.reactive.test.entity.ValueIdEntity
+import io.clroot.hibernate.reactive.test.repository.ValueIdEntityRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.toList
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.atomic.AtomicLong
+
+@SpringBootTest(classes = [TestApplication::class])
+class ValueClassIdIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var repository: ValueIdEntityRepository
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    private val identifiers = AtomicLong(10_000)
+
+    init {
+        describe("Kotlin value class repository identifiers") {
+            it("finds an entity by its wrapped identifier") {
+                val id = ValueEntityId(identifiers.incrementAndGet())
+                tx.transactional {
+                    repository.save(ValueIdEntity(id, "value-id"))
+                }
+
+                val found = tx.readOnly {
+                    repository.findById(id)
+                }
+
+                found?.id shouldBe id
+                found?.name shouldBe "value-id"
+                repository.existsById(id) shouldBe true
+            }
+
+            it("finds entities by wrapped identifier collections") {
+                val ids = listOf(
+                    ValueEntityId(identifiers.incrementAndGet()),
+                    ValueEntityId(identifiers.incrementAndGet()),
+                )
+                tx.transactional {
+                    ids.forEach { repository.save(ValueIdEntity(it, "value-${it.value}")) }
+                }
+
+                val found = repository.findAllById(ids).toList()
+
+                found.map { it.id }.toSet() shouldBe ids.toSet()
+            }
+
+            it("deletes by wrapped single and collection identifiers") {
+                val first = ValueEntityId(identifiers.incrementAndGet())
+                val second = ValueEntityId(identifiers.incrementAndGet())
+                tx.transactional {
+                    repository.save(ValueIdEntity(first, "delete-single"))
+                    repository.save(ValueIdEntity(second, "delete-collection"))
+                }
+
+                repository.deleteById(first)
+                repository.existsById(first) shouldBe false
+
+                repository.deleteAllById(listOf(second))
+                repository.existsById(second) shouldBe false
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/ValueIdEntity.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/ValueIdEntity.kt
@@ -1,0 +1,18 @@
+package io.clroot.hibernate.reactive.test.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@JvmInline
+value class ValueEntityId(
+    val value: Long,
+)
+
+@Entity
+@Table(name = "value_id_entity")
+class ValueIdEntity(
+    @Id
+    val id: ValueEntityId,
+    var name: String,
+)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ValueIdEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ValueIdEntityRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.test.repository
+
+import io.clroot.hibernate.reactive.test.entity.ValueEntityId
+import io.clroot.hibernate.reactive.test.entity.ValueIdEntity
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ValueIdEntityRepository : CoroutineCrudRepository<ValueIdEntity, ValueEntityId>


### PR DESCRIPTION
## Summary

- unwrap Kotlin `@JvmInline` repository identifiers to Hibernate's underlying JVM type
- apply the adapter consistently to single and collection ID lookup, existence, and delete operations
- cache adapters by identifier class while preserving identity behavior for ordinary IDs
- add real Hibernate Reactive integration coverage for value-class IDs in both starter variants
- document value-class identifier support in English and Korean

## Compatibility

Ordinary repository identifiers pass through unchanged. Value-class unboxing is limited to the
base repository ID boundary and does not alter arbitrary derived or annotated query arguments.

## Verification

- Boot 3 full suite: 400 tests, 0 failures
- Boot 4 full suite: 375 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 changed production, fixture, and test sources: byte-identical
- exact-SHA standards review: passed
- exact-SHA specification review: passed
