### PR TITLE
fix: preserve transaction coroutine context

### DIFF
--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -256,6 +256,9 @@ class OrderService(
 }
 ```
 
+`transactional`과 `readOnly`는 DB 작업을 필수 Vert.x dispatcher로 옮기면서도 MDC/트레이싱
+어댑터와 Reactor context 같은 호출자 코루틴 컨텍스트 요소를 유지합니다.
+
 ## Lazy Loading
 
 Hibernate Reactive에서는 동기적 Lazy Loading이 지원되지 않습니다.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -259,6 +259,9 @@ class OrderService(
 }
 ```
 
+`transactional` and `readOnly` preserve caller coroutine context elements such as MDC/tracing
+adapters and Reactor context while moving database work onto the required Vert.x dispatcher.
+
 ## Lazy Loading
 
 Synchronous Lazy Loading is not supported in Hibernate Reactive.

--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
@@ -102,6 +102,7 @@ class ReactiveTransactionExecutor(
     ): T {
         val parentContext = currentContextOrNull()
         val effectiveTimeout = calculateEffectiveTimeout(parentContext, timeout)
+        val callerContext = currentCoroutineContext().minusKey(Job)
 
         return if (parentContext != null) {
             // 기존 세션 재사용 (REQUIRED 동작)
@@ -111,7 +112,7 @@ class ReactiveTransactionExecutor(
             executeWithTimeout(effectiveTimeout) {
                 sessionStarter { session ->
                     val vertxDispatcher = requireVertxContext().dispatcher()
-                    CoroutineScope(vertxDispatcher)
+                    CoroutineScope(callerContext + vertxDispatcher)
                         .async {
                             val newContext = ReactiveSessionContext(
                                 session = session,

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
@@ -9,6 +9,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 
@@ -129,6 +133,16 @@ class ReactiveTransactionIntegrationTest : IntegrationTestBase() {
                     }
 
                     result shouldBe "nested success"
+                }
+
+                it("호출자의 코루틴 컨텍스트를 트랜잭션 블록에 전파한다") {
+                    val traceContext = ThreadLocal<String>()
+                    withContext(CoroutineName("request-trace") + traceContext.asContextElement("trace-123")) {
+                        tx.transactional {
+                            currentCoroutineContext()[CoroutineName]?.name shouldBe "request-trace"
+                            traceContext.get() shouldBe "trace-123"
+                        }
+                    }
                 }
             }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
@@ -9,6 +9,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 
@@ -129,6 +133,16 @@ class ReactiveTransactionIntegrationTest : IntegrationTestBase() {
                     }
 
                     result shouldBe "nested success"
+                }
+
+                it("호출자의 코루틴 컨텍스트를 트랜잭션 블록에 전파한다") {
+                    val traceContext = ThreadLocal<String>()
+                    withContext(CoroutineName("request-trace") + traceContext.asContextElement("trace-123")) {
+                        tx.transactional {
+                            currentCoroutineContext()[CoroutineName]?.name shouldBe "request-trace"
+                            traceContext.get() shouldBe "trace-123"
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- preserve caller coroutine context elements across `ReactiveTransactionExecutor` boundaries
- remove only the caller `Job` before starting the Vert.x-bound transaction coroutine
- retain the required Vert.x dispatcher while carrying MDC/tracing/Reactor-style elements
- add real transaction integration coverage for ordinary and thread-local context elements
- document the propagation contract in English and Korean

## Compatibility

Database work continues to run on the captured Vert.x dispatcher. Nested transactions retain their
existing session-reuse path; the change applies when a new transaction or read-only session starts.

## Verification

- core full suite: 31 tests, 0 failures
- Boot 3 full suite: 401 tests, 0 failures
- Boot 4 full suite: 376 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 changed integration tests: byte-identical
- exact-SHA standards review: passed
- exact-SHA specification review: passed
