### PR TITLE
fix: enforce read-only session settings

### DIFF
--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -258,6 +258,8 @@ class OrderService(
 
 `transactional`과 `readOnly`는 DB 작업을 필수 Vert.x dispatcher로 옮기면서도 MDC/트레이싱
 어댑터와 Reactor context 같은 호출자 코루틴 컨텍스트 요소를 유지합니다.
+새로 여는 `readOnly` 세션에서는 Hibernate의 dirty checking과 자동 flush를 비활성화하므로,
+조회한 엔티티의 변경이 암묵적으로 DB에 반영되지 않습니다.
 
 ## Lazy Loading
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -261,6 +261,8 @@ class OrderService(
 
 `transactional` and `readOnly` preserve caller coroutine context elements such as MDC/tracing
 adapters and Reactor context while moving database work onto the required Vert.x dispatcher.
+For a newly opened `readOnly` session, Hibernate dirty checking and automatic flush are disabled,
+so changes made to loaded entities are not written implicitly.
 
 ## Lazy Loading
 

--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
@@ -6,6 +6,7 @@ import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.vertx.core.Vertx
 import io.vertx.kotlin.coroutines.dispatcher
 import kotlinx.coroutines.*
+import org.hibernate.FlushMode
 import org.hibernate.reactive.mutiny.Mutiny
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.INFINITE
@@ -69,6 +70,7 @@ class ReactiveTransactionExecutor(
      * 읽기 전용 세션을 시작합니다.
      *
      * 블록 내 모든 Port 호출이 동일한 세션을 공유하며,
+     * 새 세션은 기본 read-only 및 수동 flush 모드로 설정되어 로드된 엔티티의 변경이 자동 반영되지 않습니다.
      * 이미 세션 컨텍스트 안에 있으면 기존 세션을 재사용합니다 (중첩 안전).
      *
      * @param timeout 세션 타임아웃 (기본 30초). 중첩 시 부모의 남은 시간과 비교하여 더 짧은 값 적용.
@@ -79,7 +81,14 @@ class ReactiveTransactionExecutor(
     ): T = executeInSession(
         mode = TransactionMode.READ_ONLY,
         timeout = timeout,
-        sessionStarter = { callback -> sessionFactory.withSession(callback) },
+        sessionStarter = { callback ->
+            sessionFactory.withSession { session ->
+                session
+                    .setDefaultReadOnly(true)
+                    .setFlushMode(FlushMode.MANUAL)
+                callback.apply(session)
+            }
+        },
         block = block,
     )
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
+import org.hibernate.FlushMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 
@@ -175,6 +176,36 @@ class ReactiveTransactionIntegrationTest : IntegrationTestBase() {
                             }
                         }
                     }
+                }
+
+                it("dirty checking과 auto-flush를 비활성화한다") {
+                    val entity = TestEntity(name = "readOnlyDirtyChecking", value = 100)
+                    val saved = tx.transactional {
+                        sessions.write { session ->
+                            session.persist(entity).replaceWith(entity)
+                        }
+                    }
+
+                    tx.readOnly {
+                        sessions.read { session ->
+                            session.isDefaultReadOnly shouldBe true
+                            session.flushMode shouldBe FlushMode.MANUAL
+
+                            session.find(TestEntity::class.java, saved.id)
+                                .invoke { found -> found.value = 999 }
+                                .chain { _: TestEntity ->
+                                    session.createQuery("SELECT e FROM TestEntity e", TestEntity::class.java)
+                                        .resultList
+                                }
+                                .replaceWith(Unit)
+                        }
+                    }
+
+                    val found = sessions.read { session ->
+                        session.find(TestEntity::class.java, saved.id)
+                    }
+                    found.shouldNotBeNull()
+                    found.value shouldBe 100
                 }
             }
         }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/ReactiveTransactionIntegrationTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
+import org.hibernate.FlushMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 
@@ -175,6 +176,36 @@ class ReactiveTransactionIntegrationTest : IntegrationTestBase() {
                             }
                         }
                     }
+                }
+
+                it("dirty checking과 auto-flush를 비활성화한다") {
+                    val entity = TestEntity(name = "readOnlyDirtyChecking", value = 100)
+                    val saved = tx.transactional {
+                        sessions.write { session ->
+                            session.persist(entity).replaceWith(entity)
+                        }
+                    }
+
+                    tx.readOnly {
+                        sessions.read { session ->
+                            session.isDefaultReadOnly shouldBe true
+                            session.flushMode shouldBe FlushMode.MANUAL
+
+                            session.find(TestEntity::class.java, saved.id)
+                                .invoke { found -> found.value = 999 }
+                                .chain { _: TestEntity ->
+                                    session.createQuery("SELECT e FROM TestEntity e", TestEntity::class.java)
+                                        .resultList
+                                }
+                                .replaceWith(Unit)
+                        }
+                    }
+
+                    val found = sessions.read { session ->
+                        session.find(TestEntity::class.java, saved.id)
+                    }
+                    found.shouldNotBeNull()
+                    found.value shouldBe 100
                 }
             }
         }


### PR DESCRIPTION
## Summary

- configure newly opened `readOnly` sessions with Hibernate default read-only mode
- use `FlushMode.MANUAL` to suppress query-triggered automatic flush
- add real Boot 3/4 integration coverage for session settings and dirty entity behavior
- document the read-only session contract in English and Korean

## Compatibility

Existing sessions continue to follow REQUIRED reuse semantics. The configuration applies only when
`ReactiveTransactionExecutor.readOnly` opens a new session, and the public API is unchanged.

## Verification

- TDD red: integration test observed `isDefaultReadOnly == false` before the implementation
- core full suite: 31 tests, 0 failures
- Boot 3 full suite: 402 tests, 0 failures
- Boot 4 full suite: 377 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 changed integration tests: byte-identical
- exact-SHA standards review: passed
- exact-SHA specification review: passed
