### PR TITLE
fix: fail closed on SSL misconfiguration

### DIFF
--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -20,7 +20,8 @@ spring:
         format_sql: true
         reactive:
           pool-size: 10
-          ssl-mode: disable
+          ssl-mode: verify-full
+          trust-certificate: /run/secrets/postgres-ca.pem
 ```
 
 ### 커넥션 풀
@@ -39,9 +40,14 @@ spring:
 | `disable`     | SSL 사용 안함 (기본값)      |
 | `allow`       | 서버가 요구하면 SSL 사용    |
 | `prefer`      | SSL 시도, 실패 시 비암호화  |
-| `require`     | SSL 필수 (인증서 검증 안함) |
-| `verify-ca`   | SSL + CA 인증서 검증        |
-| `verify-full` | SSL + CA + 호스트명 검증    |
+| `require`     | SSL 필수 + 기본 trust store 인증서 검증 |
+| `verify-ca`   | SSL + 지정한 CA 인증서 검증             |
+| `verify-full` | SSL + 지정한 CA + 호스트명 검증         |
+
+`verify-ca`와 `verify-full`에서는 PEM CA 인증서 경로인 `trust-certificate`를 반드시 지정해야
+합니다. `require`에서 별도 인증서를 지정하지 않으면 JVM 기본 trust store를 사용합니다.
+잘못된 모드, 필수 인증서 누락, PostgreSQL 클라이언트 클래스 부재, TLS 리플렉션 실패가 있으면
+평문 연결로 조용히 전환하지 않고 애플리케이션 시작을 중단합니다.
 
 ### Repository 스캔
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -22,7 +22,8 @@ spring:
         format_sql: true
         reactive:
           pool-size: 10
-          ssl-mode: disable
+          ssl-mode: verify-full
+          trust-certificate: /run/secrets/postgres-ca.pem
 ```
 
 ### Connection Pool
@@ -41,9 +42,14 @@ spring:
 | `disable`     | No SSL (default)                         |
 | `allow`       | Use SSL if server requires it            |
 | `prefer`      | Try SSL, fall back to unencrypted        |
-| `require`     | SSL required (no certificate validation) |
-| `verify-ca`   | SSL + CA certificate validation          |
-| `verify-full` | SSL + CA + hostname validation           |
+| `require`     | SSL required + default trust store validation |
+| `verify-ca`   | SSL + configured CA certificate validation    |
+| `verify-full` | SSL + configured CA + hostname validation     |
+
+`verify-ca` and `verify-full` require `trust-certificate`, which must point to a PEM CA certificate.
+`require` uses the JVM default trust store when no custom certificate is configured. Invalid modes,
+missing required certificates, unavailable PostgreSQL client classes, and TLS reflection failures
+stop startup instead of silently falling back to plaintext.
 
 ### Repository Scanning
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
@@ -38,14 +38,15 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
  * - `spring.jpa.show-sql`, `spring.jpa.properties.hibernate.format_sql`
  *
  * Hibernate Reactive 전용 프로퍼티:
- * - `kotlin.hibernate.reactive.pool-size`: 커넥션 풀 사이즈 (기본값: 10)
- * - `kotlin.hibernate.reactive.ssl-mode`: SSL 모드 (기본값: disable)
- * - `kotlin.hibernate.reactive.connect-timeout`: 커넥션 요청 타임아웃 (밀리초)
- * - `kotlin.hibernate.reactive.idle-timeout`: 유휴 커넥션 타임아웃 (밀리초)
- * - `kotlin.hibernate.reactive.max-wait-queue-size`: 대기 큐 최대 크기
+ * - `spring.jpa.properties.hibernate.reactive.pool-size`: 커넥션 풀 사이즈 (기본값: 10)
+ * - `spring.jpa.properties.hibernate.reactive.ssl-mode`: SSL 모드 (기본값: disable)
+ * - `spring.jpa.properties.hibernate.reactive.trust-certificate`: PEM CA 인증서 경로
+ * - `spring.jpa.properties.hibernate.reactive.connect-timeout`: 커넥션 요청 타임아웃 (밀리초)
+ * - `spring.jpa.properties.hibernate.reactive.idle-timeout`: 유휴 커넥션 타임아웃 (밀리초)
+ * - `spring.jpa.properties.hibernate.reactive.max-wait-queue-size`: 대기 큐 최대 크기
  *
  * SSL 모드는 다음 우선순위로 적용됩니다:
- * 1. `kotlin.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
+ * 1. `spring.jpa.properties.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
  * 2. JDBC URL의 `sslmode` 파라미터 (예: `?sslmode=require`)
  */
 @AutoConfiguration
@@ -192,6 +193,12 @@ class HibernateReactiveAutoConfiguration(
                 SslAwareSqlClientPoolConfiguration::class.java.name
             )
             configuration.setProperty("hibernate.vertx.pool.ssl.mode", sslMode)
+            applicationContext.environment
+                .getProperty("spring.jpa.properties.hibernate.reactive.trust-certificate")
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    configuration.setProperty("hibernate.vertx.pool.ssl.trust-certificate", it)
+                }
         }
 
         val serviceRegistry =
@@ -206,7 +213,7 @@ class HibernateReactiveAutoConfiguration(
      * SSL 모드를 결정합니다.
      *
      * 우선순위:
-     * 1. `kotlin.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
+     * 1. `spring.jpa.properties.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
      * 2. JDBC URL의 `sslmode` 파라미터
      *
      * @return SSL 모드 문자열 또는 null

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
@@ -37,11 +37,11 @@ data class HibernateReactiveProperties(
      * - `disable`: SSL 사용 안함
      * - `allow`: 서버가 요구하면 SSL 사용
      * - `prefer`: SSL 시도, 실패 시 비암호화
-     * - `require`: SSL 필수 (인증서 검증 안함)
-     * - `verify-ca`: SSL + CA 인증서 검증
-     * - `verify-full`: SSL + CA + 호스트명 검증
+     * - `require`: SSL 필수 (기본 trust store로 인증서 검증)
+     * - `verify-ca`: SSL + 지정한 CA 인증서 검증
+     * - `verify-full`: SSL + 지정한 CA + 호스트명 검증
      *
-     * AWS RDS 연결 시 `require` 권장
+     * 프로덕션에서는 CA 인증서를 지정한 `verify-full` 권장
      */
     val sslMode: String = "disable",
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration.kt
@@ -16,8 +16,10 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
 
     companion object {
         private const val SSL_MODE_PROPERTY = "hibernate.vertx.pool.ssl.mode"
+        private const val TRUST_CERTIFICATE_PROPERTY = "hibernate.vertx.pool.ssl.trust-certificate"
         private const val PG_CONNECT_OPTIONS_CLASS = "io.vertx.pgclient.PgConnectOptions"
         private const val SSL_MODE_CLASS = "io.vertx.pgclient.SslMode"
+        private const val PEM_TRUST_OPTIONS_CLASS = "io.vertx.core.net.PemTrustOptions"
 
         private val logger = LoggerFactory.getLogger(SslAwareSqlClientPoolConfiguration::class.java)
 
@@ -29,34 +31,52 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
                 Class.forName(PG_CONNECT_OPTIONS_CLASS)
                 true
             } catch (e: ClassNotFoundException) {
-                logger.debug("vertx-pg-client not found in classpath, SSL mode configuration will be skipped")
                 false
             }
         }
     }
 
     private var sslMode: String? = null
+    private var trustCertificate: String? = null
 
     override fun configure(configuration: MutableMap<Any?, Any?>?) {
         super.configure(configuration)
-        sslMode = ConfigurationHelper.getString(SSL_MODE_PROPERTY, configuration)
-        logger.info("SslAwareSqlClientPoolConfiguration configured with sslMode: {}", sslMode)
+        sslMode = ConfigurationHelper.getString(SSL_MODE_PROPERTY, configuration)?.trim()?.lowercase()
+        trustCertificate = ConfigurationHelper.getString(TRUST_CERTIFICATE_PROPERTY, configuration)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        logger.info(
+            "SslAwareSqlClientPoolConfiguration configured with sslMode: {}, trustCertificate: {}",
+            sslMode,
+            trustCertificate?.let { "configured" } ?: "default trust store",
+        )
     }
 
     override fun connectOptions(uri: URI): SqlConnectOptions {
         val baseOptions = super.connectOptions(uri)
 
         // SSL 모드가 설정되지 않았거나 disable이면 기본 옵션 반환
-        if (sslMode.isNullOrBlank() || sslMode == "disable") {
+        if (sslMode == null || sslMode == "disable") {
             return baseOptions
         }
 
-        // PostgreSQL이고 vertx-pg-client가 있으면 PgConnectOptions로 변환
-        if (isPostgresUri(uri) && pgClientAvailable) {
-            return createPgConnectOptionsWithSsl(baseOptions)
+        if (sslMode.isNullOrBlank()) {
+            throw IllegalStateException("PostgreSQL SSL mode must not be blank")
         }
 
-        return baseOptions
+        if (!isPostgresUri(uri)) {
+            throw IllegalStateException(
+                "PostgreSQL SSL mode '$sslMode' was configured for unsupported database URI '$uri'",
+            )
+        }
+
+        if (!pgClientAvailable) {
+            throw IllegalStateException(
+                "PostgreSQL SSL mode '$sslMode' requires vertx-pg-client on the runtime classpath",
+            )
+        }
+
+        return createPgConnectOptionsWithSsl(baseOptions)
     }
 
     /**
@@ -72,6 +92,14 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
      * Reflection을 사용하여 vertx-pg-client 의존성 없이 동작합니다.
      */
     private fun createPgConnectOptionsWithSsl(baseOptions: SqlConnectOptions): SqlConnectOptions {
+        val configuredSslMode = requireNotNull(sslMode)
+        if (configuredSslMode in setOf("verify-ca", "verify-full") && trustCertificate == null) {
+            throw IllegalStateException(
+                "SSL mode '$configuredSslMode' requires " +
+                    "spring.jpa.properties.hibernate.reactive.trust-certificate",
+            )
+        }
+
         try {
             val pgConnectOptionsClass = Class.forName(PG_CONNECT_OPTIONS_CLASS)
             val sslModeClass = Class.forName(SSL_MODE_CLASS)
@@ -84,26 +112,54 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
 
             // SSL 모드 설정
             val sslModeOfMethod = sslModeClass.getMethod("of", String::class.java)
-            val sslModeValue = sslModeOfMethod.invoke(null, sslMode)
+            val sslModeValue = sslModeOfMethod.invoke(null, configuredSslMode)
             val setSslModeMethod = pgConnectOptionsClass.getMethod("setSslMode", sslModeClass)
             setSslModeMethod.invoke(pgOptions, sslModeValue)
 
-            // require 모드에서는 인증서 검증 없이 암호화만 사용 (AWS RDS 등)
-            // verify-ca, verify-full 모드에서는 trustAll을 false로 유지
-            if (sslMode == "require" || sslMode == "prefer" || sslMode == "allow") {
-                val setTrustAllMethod = pgConnectOptionsClass.getMethod("setTrustAll", Boolean::class.java)
-                setTrustAllMethod.invoke(pgOptions, true)
-                logger.debug("Set trustAll=true for SSL mode '{}'", sslMode)
+            // 어떤 SSL 모드에서도 인증서 검증을 우회하지 않음
+            val setTrustAllMethod = pgConnectOptionsClass.getMethod("setTrustAll", Boolean::class.java)
+            setTrustAllMethod.invoke(pgOptions, false)
+
+            trustCertificate?.let { certificatePath ->
+                applyTrustCertificate(pgOptions, pgConnectOptionsClass, certificatePath)
             }
 
-            logger.info("Created PgConnectOptions with SSL mode '{}' for PostgreSQL connection", sslMode)
+            if (configuredSslMode == "verify-full") {
+                val setHostnameVerificationMethod = pgConnectOptionsClass.getMethod(
+                    "setHostnameVerificationAlgorithm",
+                    String::class.java,
+                )
+                setHostnameVerificationMethod.invoke(pgOptions, "HTTPS")
+            }
+
+            logger.info(
+                "Created PgConnectOptions with verified SSL mode '{}' for PostgreSQL connection",
+                configuredSslMode,
+            )
 
             return pgOptions as SqlConnectOptions
         } catch (e: Exception) {
-            logger.warn("Failed to create PgConnectOptions with SSL mode '{}': {}", sslMode, e.message)
-            logger.debug("SSL mode configuration error details", e)
-            return baseOptions
+            throw IllegalStateException(
+                "Failed to configure PostgreSQL SSL mode '$configuredSslMode'; " +
+                    "refusing to continue without the requested TLS settings",
+                e,
+            )
         }
+    }
+
+    private fun applyTrustCertificate(
+        pgOptions: Any,
+        pgConnectOptionsClass: Class<*>,
+        certificatePath: String,
+    ) {
+        val pemTrustOptionsClass = Class.forName(PEM_TRUST_OPTIONS_CLASS)
+        val pemTrustOptions = pemTrustOptionsClass.getDeclaredConstructor().newInstance()
+        pemTrustOptionsClass
+            .getMethod("addCertPath", String::class.java)
+            .invoke(pemTrustOptions, certificatePath)
+        pgConnectOptionsClass
+            .getMethod("setPemTrustOptions", pemTrustOptionsClass)
+            .invoke(pgOptions, pemTrustOptions)
     }
 
     /**
@@ -122,31 +178,23 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
         )
 
         for ((methodName, valueProvider) in setters) {
-            try {
-                val value = valueProvider()
-                if (value != null) {
-                    val paramType = when (value) {
-                        is Int -> Int::class.java
-                        is Boolean -> Boolean::class.java
-                        else -> String::class.java
-                    }
-                    val method = targetClass.getMethod(methodName, paramType)
-                    method.invoke(target, value)
+            val value = valueProvider()
+            if (value != null) {
+                val paramType = when (value) {
+                    is Int -> Int::class.java
+                    is Boolean -> Boolean::class.java
+                    else -> String::class.java
                 }
-            } catch (e: Exception) {
-                logger.trace("Could not copy option via {}: {}", methodName, e.message)
+                val method = targetClass.getMethod(methodName, paramType)
+                method.invoke(target, value)
             }
         }
 
         // Properties 복사
-        try {
-            val properties = source.properties
-            if (properties != null && properties.isNotEmpty()) {
-                val setPropertiesMethod = targetClass.getMethod("setProperties", Map::class.java)
-                setPropertiesMethod.invoke(target, properties)
-            }
-        } catch (e: Exception) {
-            logger.trace("Could not copy properties: {}", e.message)
+        val properties = source.properties
+        if (properties != null && properties.isNotEmpty()) {
+            val setPropertiesMethod = targetClass.getMethod("setProperties", Map::class.java)
+            setPropertiesMethod.invoke(target, properties)
         }
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -200,9 +200,15 @@
     {
       "name": "spring.jpa.properties.hibernate.reactive.ssl-mode",
       "type": "java.lang.String",
-      "description": "Vert.x PG Client SSL mode. For AWS RDS, use 'require'.",
+      "description": "Vert.x PG Client SSL mode. TLS configuration failures stop startup instead of falling back to plaintext.",
       "defaultValue": "disable",
       "sourceType": "io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveProperties"
+    },
+    {
+      "name": "spring.jpa.properties.hibernate.reactive.trust-certificate",
+      "type": "java.lang.String",
+      "description": "Path to a PEM CA certificate. Required for verify-ca and verify-full; optional for require.",
+      "sourceType": "io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveAutoConfiguration"
     },
     {
       "name": "spring.jpa.properties.hibernate.reactive.connect-timeout",
@@ -249,9 +255,9 @@
         {"value": "disable", "description": "No SSL"},
         {"value": "allow", "description": "Use SSL if server requires it"},
         {"value": "prefer", "description": "Try SSL first, fall back to non-encrypted"},
-        {"value": "require", "description": "SSL required (no certificate verification)"},
-        {"value": "verify-ca", "description": "SSL + CA certificate verification"},
-        {"value": "verify-full", "description": "SSL + CA + hostname verification"}
+        {"value": "require", "description": "SSL required with default trust store validation"},
+        {"value": "verify-ca", "description": "SSL + configured CA certificate verification"},
+        {"value": "verify-full", "description": "SSL + configured CA + hostname verification"}
       ]
     },
     {

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfigurationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfigurationTest.kt
@@ -1,0 +1,88 @@
+package io.clroot.hibernate.reactive.spring.boot.pool
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.vertx.core.net.PemTrustOptions
+import io.vertx.pgclient.PgConnectOptions
+import io.vertx.pgclient.SslMode
+import java.net.URI
+
+class SslAwareSqlClientPoolConfigurationTest : FunSpec({
+
+    test("invalid SSL mode fails closed") {
+        val configuration = sslConfiguration("reqire")
+
+        shouldThrow<IllegalStateException> {
+            configuration.connectOptions(POSTGRES_URI)
+        }
+    }
+
+    test("blank SSL mode fails closed") {
+        val configuration = sslConfiguration("   ")
+
+        shouldThrow<IllegalStateException> {
+            configuration.connectOptions(POSTGRES_URI)
+        }
+    }
+
+    test("require mode keeps certificate verification enabled") {
+        val options = sslConfiguration("require").connectOptions(POSTGRES_URI) as PgConnectOptions
+
+        options.sslMode shouldBe SslMode.REQUIRE
+        options.isTrustAll shouldBe false
+    }
+
+    test("verify-ca requires an explicit trust certificate") {
+        val configuration = sslConfiguration("verify-ca")
+
+        shouldThrow<IllegalStateException> {
+            configuration.connectOptions(POSTGRES_URI)
+        }
+    }
+
+    test("trust certificate is applied as PEM trust options") {
+        val options = sslConfiguration(
+            mode = "verify-ca",
+            trustCertificate = "/run/secrets/postgres-ca.pem",
+        ).connectOptions(POSTGRES_URI) as PgConnectOptions
+
+        options.sslMode shouldBe SslMode.VERIFY_CA
+        (options.trustOptions as PemTrustOptions).certPaths shouldContainExactly
+            listOf("/run/secrets/postgres-ca.pem")
+        options.isTrustAll shouldBe false
+    }
+
+    test("verify-full enables hostname verification") {
+        val options = sslConfiguration(
+            mode = "verify-full",
+            trustCertificate = "/run/secrets/postgres-ca.pem",
+        ).connectOptions(POSTGRES_URI) as PgConnectOptions
+
+        options.sslMode shouldBe SslMode.VERIFY_FULL
+        options.hostnameVerificationAlgorithm shouldBe "HTTPS"
+    }
+}) {
+    companion object {
+        private val POSTGRES_URI = URI("postgresql://localhost:5432/test")
+        private const val SSL_MODE_PROPERTY = "hibernate.vertx.pool.ssl.mode"
+        private const val TRUST_CERTIFICATE_PROPERTY = "hibernate.vertx.pool.ssl.trust-certificate"
+
+        private fun sslConfiguration(
+            mode: String,
+            trustCertificate: String? = null,
+        ): SslAwareSqlClientPoolConfiguration {
+            val properties = mutableMapOf<Any?, Any?>(
+                SSL_MODE_PROPERTY to mode,
+                "hibernate.connection.username" to "test",
+                "hibernate.connection.password" to "test",
+            )
+            trustCertificate?.let { properties[TRUST_CERTIFICATE_PROPERTY] = it }
+
+            return SslAwareSqlClientPoolConfiguration().apply {
+                configure(properties)
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
@@ -37,14 +37,15 @@ import org.springframework.core.type.filter.AnnotationTypeFilter
  * - `spring.jpa.show-sql`, `spring.jpa.properties.hibernate.format_sql`
  *
  * Hibernate Reactive 전용 프로퍼티:
- * - `kotlin.hibernate.reactive.pool-size`: 커넥션 풀 사이즈 (기본값: 10)
- * - `kotlin.hibernate.reactive.ssl-mode`: SSL 모드 (기본값: disable)
- * - `kotlin.hibernate.reactive.connect-timeout`: 커넥션 요청 타임아웃 (밀리초)
- * - `kotlin.hibernate.reactive.idle-timeout`: 유휴 커넥션 타임아웃 (밀리초)
- * - `kotlin.hibernate.reactive.max-wait-queue-size`: 대기 큐 최대 크기
+ * - `spring.jpa.properties.hibernate.reactive.pool-size`: 커넥션 풀 사이즈 (기본값: 10)
+ * - `spring.jpa.properties.hibernate.reactive.ssl-mode`: SSL 모드 (기본값: disable)
+ * - `spring.jpa.properties.hibernate.reactive.trust-certificate`: PEM CA 인증서 경로
+ * - `spring.jpa.properties.hibernate.reactive.connect-timeout`: 커넥션 요청 타임아웃 (밀리초)
+ * - `spring.jpa.properties.hibernate.reactive.idle-timeout`: 유휴 커넥션 타임아웃 (밀리초)
+ * - `spring.jpa.properties.hibernate.reactive.max-wait-queue-size`: 대기 큐 최대 크기
  *
  * SSL 모드는 다음 우선순위로 적용됩니다:
- * 1. `kotlin.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
+ * 1. `spring.jpa.properties.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
  * 2. JDBC URL의 `sslmode` 파라미터 (예: `?sslmode=require`)
  */
 @AutoConfiguration
@@ -190,6 +191,12 @@ class HibernateReactiveAutoConfiguration(
                 SslAwareSqlClientPoolConfiguration::class.java.name
             )
             configuration.setProperty("hibernate.vertx.pool.ssl.mode", sslMode)
+            applicationContext.environment
+                .getProperty("spring.jpa.properties.hibernate.reactive.trust-certificate")
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    configuration.setProperty("hibernate.vertx.pool.ssl.trust-certificate", it)
+                }
         }
 
         val serviceRegistry =
@@ -204,7 +211,7 @@ class HibernateReactiveAutoConfiguration(
      * SSL 모드를 결정합니다.
      *
      * 우선순위:
-     * 1. `kotlin.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
+     * 1. `spring.jpa.properties.hibernate.reactive.ssl-mode` 프로퍼티 (disable이 아닌 경우)
      * 2. JDBC URL의 `sslmode` 파라미터
      *
      * @return SSL 모드 문자열 또는 null

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
@@ -37,11 +37,11 @@ data class HibernateReactiveProperties(
      * - `disable`: SSL 사용 안함
      * - `allow`: 서버가 요구하면 SSL 사용
      * - `prefer`: SSL 시도, 실패 시 비암호화
-     * - `require`: SSL 필수 (인증서 검증 안함)
-     * - `verify-ca`: SSL + CA 인증서 검증
-     * - `verify-full`: SSL + CA + 호스트명 검증
+     * - `require`: SSL 필수 (기본 trust store로 인증서 검증)
+     * - `verify-ca`: SSL + 지정한 CA 인증서 검증
+     * - `verify-full`: SSL + 지정한 CA + 호스트명 검증
      *
-     * AWS RDS 연결 시 `require` 권장
+     * 프로덕션에서는 CA 인증서를 지정한 `verify-full` 권장
      */
     val sslMode: String = "disable",
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration.kt
@@ -16,8 +16,10 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
 
     companion object {
         private const val SSL_MODE_PROPERTY = "hibernate.vertx.pool.ssl.mode"
+        private const val TRUST_CERTIFICATE_PROPERTY = "hibernate.vertx.pool.ssl.trust-certificate"
         private const val PG_CONNECT_OPTIONS_CLASS = "io.vertx.pgclient.PgConnectOptions"
         private const val SSL_MODE_CLASS = "io.vertx.pgclient.SslMode"
+        private const val PEM_TRUST_OPTIONS_CLASS = "io.vertx.core.net.PemTrustOptions"
 
         private val logger = LoggerFactory.getLogger(SslAwareSqlClientPoolConfiguration::class.java)
 
@@ -29,34 +31,52 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
                 Class.forName(PG_CONNECT_OPTIONS_CLASS)
                 true
             } catch (e: ClassNotFoundException) {
-                logger.debug("vertx-pg-client not found in classpath, SSL mode configuration will be skipped")
                 false
             }
         }
     }
 
     private var sslMode: String? = null
+    private var trustCertificate: String? = null
 
     override fun configure(configuration: MutableMap<Any?, Any?>?) {
         super.configure(configuration)
-        sslMode = ConfigurationHelper.getString(SSL_MODE_PROPERTY, configuration)
-        logger.info("SslAwareSqlClientPoolConfiguration configured with sslMode: {}", sslMode)
+        sslMode = ConfigurationHelper.getString(SSL_MODE_PROPERTY, configuration)?.trim()?.lowercase()
+        trustCertificate = ConfigurationHelper.getString(TRUST_CERTIFICATE_PROPERTY, configuration)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        logger.info(
+            "SslAwareSqlClientPoolConfiguration configured with sslMode: {}, trustCertificate: {}",
+            sslMode,
+            trustCertificate?.let { "configured" } ?: "default trust store",
+        )
     }
 
     override fun connectOptions(uri: URI): SqlConnectOptions {
         val baseOptions = super.connectOptions(uri)
 
         // SSL 모드가 설정되지 않았거나 disable이면 기본 옵션 반환
-        if (sslMode.isNullOrBlank() || sslMode == "disable") {
+        if (sslMode == null || sslMode == "disable") {
             return baseOptions
         }
 
-        // PostgreSQL이고 vertx-pg-client가 있으면 PgConnectOptions로 변환
-        if (isPostgresUri(uri) && pgClientAvailable) {
-            return createPgConnectOptionsWithSsl(baseOptions)
+        if (sslMode.isNullOrBlank()) {
+            throw IllegalStateException("PostgreSQL SSL mode must not be blank")
         }
 
-        return baseOptions
+        if (!isPostgresUri(uri)) {
+            throw IllegalStateException(
+                "PostgreSQL SSL mode '$sslMode' was configured for unsupported database URI '$uri'",
+            )
+        }
+
+        if (!pgClientAvailable) {
+            throw IllegalStateException(
+                "PostgreSQL SSL mode '$sslMode' requires vertx-pg-client on the runtime classpath",
+            )
+        }
+
+        return createPgConnectOptionsWithSsl(baseOptions)
     }
 
     /**
@@ -72,6 +92,14 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
      * Reflection을 사용하여 vertx-pg-client 의존성 없이 동작합니다.
      */
     private fun createPgConnectOptionsWithSsl(baseOptions: SqlConnectOptions): SqlConnectOptions {
+        val configuredSslMode = requireNotNull(sslMode)
+        if (configuredSslMode in setOf("verify-ca", "verify-full") && trustCertificate == null) {
+            throw IllegalStateException(
+                "SSL mode '$configuredSslMode' requires " +
+                    "spring.jpa.properties.hibernate.reactive.trust-certificate",
+            )
+        }
+
         try {
             val pgConnectOptionsClass = Class.forName(PG_CONNECT_OPTIONS_CLASS)
             val sslModeClass = Class.forName(SSL_MODE_CLASS)
@@ -84,26 +112,54 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
 
             // SSL 모드 설정
             val sslModeOfMethod = sslModeClass.getMethod("of", String::class.java)
-            val sslModeValue = sslModeOfMethod.invoke(null, sslMode)
+            val sslModeValue = sslModeOfMethod.invoke(null, configuredSslMode)
             val setSslModeMethod = pgConnectOptionsClass.getMethod("setSslMode", sslModeClass)
             setSslModeMethod.invoke(pgOptions, sslModeValue)
 
-            // require 모드에서는 인증서 검증 없이 암호화만 사용 (AWS RDS 등)
-            // verify-ca, verify-full 모드에서는 trustAll을 false로 유지
-            if (sslMode == "require" || sslMode == "prefer" || sslMode == "allow") {
-                val setTrustAllMethod = pgConnectOptionsClass.getMethod("setTrustAll", Boolean::class.java)
-                setTrustAllMethod.invoke(pgOptions, true)
-                logger.debug("Set trustAll=true for SSL mode '{}'", sslMode)
+            // 어떤 SSL 모드에서도 인증서 검증을 우회하지 않음
+            val setTrustAllMethod = pgConnectOptionsClass.getMethod("setTrustAll", Boolean::class.java)
+            setTrustAllMethod.invoke(pgOptions, false)
+
+            trustCertificate?.let { certificatePath ->
+                applyTrustCertificate(pgOptions, pgConnectOptionsClass, certificatePath)
             }
 
-            logger.info("Created PgConnectOptions with SSL mode '{}' for PostgreSQL connection", sslMode)
+            if (configuredSslMode == "verify-full") {
+                val setHostnameVerificationMethod = pgConnectOptionsClass.getMethod(
+                    "setHostnameVerificationAlgorithm",
+                    String::class.java,
+                )
+                setHostnameVerificationMethod.invoke(pgOptions, "HTTPS")
+            }
+
+            logger.info(
+                "Created PgConnectOptions with verified SSL mode '{}' for PostgreSQL connection",
+                configuredSslMode,
+            )
 
             return pgOptions as SqlConnectOptions
         } catch (e: Exception) {
-            logger.warn("Failed to create PgConnectOptions with SSL mode '{}': {}", sslMode, e.message)
-            logger.debug("SSL mode configuration error details", e)
-            return baseOptions
+            throw IllegalStateException(
+                "Failed to configure PostgreSQL SSL mode '$configuredSslMode'; " +
+                    "refusing to continue without the requested TLS settings",
+                e,
+            )
         }
+    }
+
+    private fun applyTrustCertificate(
+        pgOptions: Any,
+        pgConnectOptionsClass: Class<*>,
+        certificatePath: String,
+    ) {
+        val pemTrustOptionsClass = Class.forName(PEM_TRUST_OPTIONS_CLASS)
+        val pemTrustOptions = pemTrustOptionsClass.getDeclaredConstructor().newInstance()
+        pemTrustOptionsClass
+            .getMethod("addCertPath", String::class.java)
+            .invoke(pemTrustOptions, certificatePath)
+        pgConnectOptionsClass
+            .getMethod("setPemTrustOptions", pemTrustOptionsClass)
+            .invoke(pgOptions, pemTrustOptions)
     }
 
     /**
@@ -122,31 +178,23 @@ class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
         )
 
         for ((methodName, valueProvider) in setters) {
-            try {
-                val value = valueProvider()
-                if (value != null) {
-                    val paramType = when (value) {
-                        is Int -> Int::class.java
-                        is Boolean -> Boolean::class.java
-                        else -> String::class.java
-                    }
-                    val method = targetClass.getMethod(methodName, paramType)
-                    method.invoke(target, value)
+            val value = valueProvider()
+            if (value != null) {
+                val paramType = when (value) {
+                    is Int -> Int::class.java
+                    is Boolean -> Boolean::class.java
+                    else -> String::class.java
                 }
-            } catch (e: Exception) {
-                logger.trace("Could not copy option via {}: {}", methodName, e.message)
+                val method = targetClass.getMethod(methodName, paramType)
+                method.invoke(target, value)
             }
         }
 
         // Properties 복사
-        try {
-            val properties = source.properties
-            if (properties != null && properties.isNotEmpty()) {
-                val setPropertiesMethod = targetClass.getMethod("setProperties", Map::class.java)
-                setPropertiesMethod.invoke(target, properties)
-            }
-        } catch (e: Exception) {
-            logger.trace("Could not copy properties: {}", e.message)
+        val properties = source.properties
+        if (properties != null && properties.isNotEmpty()) {
+            val setPropertiesMethod = targetClass.getMethod("setProperties", Map::class.java)
+            setPropertiesMethod.invoke(target, properties)
         }
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -200,9 +200,15 @@
     {
       "name": "spring.jpa.properties.hibernate.reactive.ssl-mode",
       "type": "java.lang.String",
-      "description": "Vert.x PG Client SSL mode. For AWS RDS, use 'require'.",
+      "description": "Vert.x PG Client SSL mode. TLS configuration failures stop startup instead of falling back to plaintext.",
       "defaultValue": "disable",
       "sourceType": "io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveProperties"
+    },
+    {
+      "name": "spring.jpa.properties.hibernate.reactive.trust-certificate",
+      "type": "java.lang.String",
+      "description": "Path to a PEM CA certificate. Required for verify-ca and verify-full; optional for require.",
+      "sourceType": "io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveAutoConfiguration"
     },
     {
       "name": "spring.jpa.properties.hibernate.reactive.connect-timeout",
@@ -249,9 +255,9 @@
         {"value": "disable", "description": "No SSL"},
         {"value": "allow", "description": "Use SSL if server requires it"},
         {"value": "prefer", "description": "Try SSL first, fall back to non-encrypted"},
-        {"value": "require", "description": "SSL required (no certificate verification)"},
-        {"value": "verify-ca", "description": "SSL + CA certificate verification"},
-        {"value": "verify-full", "description": "SSL + CA + hostname verification"}
+        {"value": "require", "description": "SSL required with default trust store validation"},
+        {"value": "verify-ca", "description": "SSL + configured CA certificate verification"},
+        {"value": "verify-full", "description": "SSL + configured CA + hostname verification"}
       ]
     },
     {

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfigurationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfigurationTest.kt
@@ -1,0 +1,88 @@
+package io.clroot.hibernate.reactive.spring.boot.pool
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.vertx.core.net.PemTrustOptions
+import io.vertx.pgclient.PgConnectOptions
+import io.vertx.pgclient.SslMode
+import java.net.URI
+
+class SslAwareSqlClientPoolConfigurationTest : FunSpec({
+
+    test("invalid SSL mode fails closed") {
+        val configuration = sslConfiguration("reqire")
+
+        shouldThrow<IllegalStateException> {
+            configuration.connectOptions(POSTGRES_URI)
+        }
+    }
+
+    test("blank SSL mode fails closed") {
+        val configuration = sslConfiguration("   ")
+
+        shouldThrow<IllegalStateException> {
+            configuration.connectOptions(POSTGRES_URI)
+        }
+    }
+
+    test("require mode keeps certificate verification enabled") {
+        val options = sslConfiguration("require").connectOptions(POSTGRES_URI) as PgConnectOptions
+
+        options.sslMode shouldBe SslMode.REQUIRE
+        options.isTrustAll shouldBe false
+    }
+
+    test("verify-ca requires an explicit trust certificate") {
+        val configuration = sslConfiguration("verify-ca")
+
+        shouldThrow<IllegalStateException> {
+            configuration.connectOptions(POSTGRES_URI)
+        }
+    }
+
+    test("trust certificate is applied as PEM trust options") {
+        val options = sslConfiguration(
+            mode = "verify-ca",
+            trustCertificate = "/run/secrets/postgres-ca.pem",
+        ).connectOptions(POSTGRES_URI) as PgConnectOptions
+
+        options.sslMode shouldBe SslMode.VERIFY_CA
+        (options.trustOptions as PemTrustOptions).certPaths shouldContainExactly
+            listOf("/run/secrets/postgres-ca.pem")
+        options.isTrustAll shouldBe false
+    }
+
+    test("verify-full enables hostname verification") {
+        val options = sslConfiguration(
+            mode = "verify-full",
+            trustCertificate = "/run/secrets/postgres-ca.pem",
+        ).connectOptions(POSTGRES_URI) as PgConnectOptions
+
+        options.sslMode shouldBe SslMode.VERIFY_FULL
+        options.hostnameVerificationAlgorithm shouldBe "HTTPS"
+    }
+}) {
+    companion object {
+        private val POSTGRES_URI = URI("postgresql://localhost:5432/test")
+        private const val SSL_MODE_PROPERTY = "hibernate.vertx.pool.ssl.mode"
+        private const val TRUST_CERTIFICATE_PROPERTY = "hibernate.vertx.pool.ssl.trust-certificate"
+
+        private fun sslConfiguration(
+            mode: String,
+            trustCertificate: String? = null,
+        ): SslAwareSqlClientPoolConfiguration {
+            val properties = mutableMapOf<Any?, Any?>(
+                SSL_MODE_PROPERTY to mode,
+                "hibernate.connection.username" to "test",
+                "hibernate.connection.password" to "test",
+            )
+            trustCertificate?.let { properties[TRUST_CERTIFICATE_PROPERTY] = it }
+
+            return SslAwareSqlClientPoolConfiguration().apply {
+                configure(properties)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- fail startup when configured PostgreSQL TLS settings cannot be applied
- stop forcing `trustAll=true` for `allow`, `prefer`, and `require`
- add PEM `trust-certificate` configuration for PostgreSQL
- require a configured CA for `verify-ca` and `verify-full`
- enable hostname verification for `verify-full`
- keep Boot 3/4 implementation, metadata, and tests aligned

## Compatibility

`disable` remains the default. Explicit `allow` and `prefer` retain their documented PostgreSQL
fallback semantics, but TLS setup errors no longer downgrade silently. No public constructor or
method signature changed.

## Verification

- TDD red: invalid/blank modes, forced `trustAll`, missing CA, ignored CA path, and absent hostname verification reproduced
- core full suite: 31 tests, 0 failures
- Boot 3 full suite: 408 tests, 0 failures
- Boot 4 full suite: 383 tests, 0 failures
- all-module `build -x test`: passed
- configuration metadata JSON validation: passed
- Boot 3/4 pool implementation, tests, properties, and metadata: byte-identical
- exact-SHA standards review: passed
- exact-SHA specification review: passed
