### PR TITLE
fix: sanitize PostgreSQL reactive URLs

### DIFF
--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -49,6 +49,10 @@ spring:
 잘못된 모드, 필수 인증서 누락, PostgreSQL 클라이언트 클래스 부재, TLS 리플렉션 실패가 있으면
 평문 연결로 조용히 전환하지 않고 애플리케이션 시작을 중단합니다.
 
+기존 JDBC URL의 `sslmode`와 `currentSchema` 파라미터도 계속 인식합니다. 두 값을 Hibernate
+설정으로 옮긴 뒤 Reactive 연결 URL에서는 제거하므로 PostgreSQL startup 파라미터로 잘못
+전달되지 않습니다. 그 밖의 URL 파라미터는 그대로 유지합니다.
+
 ### Repository 스캔
 
 ```kotlin

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -51,6 +51,10 @@ spring:
 missing required certificates, unavailable PostgreSQL client classes, and TLS reflection failures
 stop startup instead of silently falling back to plaintext.
 
+Legacy JDBC URL parameters `sslmode` and `currentSchema` are still recognized. After they are
+translated to Hibernate settings, they are removed from the Reactive connection URL so PostgreSQL
+does not receive them as startup parameters. Other URL parameters are preserved.
+
 ### Repository Scanning
 
 ```kotlin

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
@@ -95,7 +95,7 @@ class HibernateReactiveAutoConfiguration(
     @Bean
     @ConditionalOnMissingBean(name = ["hibernateSessionFactory"])
     fun hibernateSessionFactory(): org.hibernate.SessionFactory {
-        val reactiveUrl = jdbcUrl.replace("jdbc:", "")
+        val reactiveUrl = ReactiveConnectionUrl.fromJdbc(jdbcUrl)
 
         val configuration =
             Configuration().apply {

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrl.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrl.kt
@@ -1,0 +1,36 @@
+package io.clroot.hibernate.reactive.spring.boot.autoconfigure
+
+internal object ReactiveConnectionUrl {
+    private val consumedParameters = setOf("sslmode", "currentSchema")
+    private val postgresSchemes = setOf("postgresql", "postgres")
+
+    fun fromJdbc(jdbcUrl: String): String {
+        val reactiveUrl = jdbcUrl.removePrefix("jdbc:")
+        if (reactiveUrl.substringBefore(':').lowercase() !in postgresSchemes) {
+            return reactiveUrl
+        }
+
+        val queryStart = reactiveUrl.indexOf('?')
+        if (queryStart < 0) {
+            return reactiveUrl
+        }
+
+        val baseUrl = reactiveUrl.substring(0, queryStart)
+        val queryAndFragment = reactiveUrl.substring(queryStart + 1)
+        val fragmentStart = queryAndFragment.indexOf('#')
+        val query = if (fragmentStart < 0) queryAndFragment else queryAndFragment.substring(0, fragmentStart)
+        val fragment = if (fragmentStart < 0) "" else queryAndFragment.substring(fragmentStart)
+        val retainedParameters = query
+            .split('&')
+            .filterNot { parameter -> parameter.substringBefore('=') in consumedParameters }
+
+        return buildString {
+            append(baseUrl)
+            if (retainedParameters.isNotEmpty()) {
+                append('?')
+                append(retainedParameters.joinToString("&"))
+            }
+            append(fragment)
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrlTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrlTest.kt
@@ -1,0 +1,49 @@
+package io.clroot.hibernate.reactive.spring.boot.autoconfigure
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ReactiveConnectionUrlTest : FunSpec({
+
+    test("removes consumed SSL and schema parameters") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders" +
+                "?sslmode=verify-full&application_name=orders&currentSchema=tenant",
+        ) shouldBe "postgresql://localhost:5432/orders?application_name=orders"
+    }
+
+    test("removes the query delimiter when every parameter is consumed") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders?currentSchema=tenant&sslmode=require",
+        ) shouldBe "postgresql://localhost:5432/orders"
+    }
+
+    test("removes every duplicate consumed parameter and preserves unrelated parameters") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders" +
+                "?targetServerType=primary&sslmode=require&sslmode=verify-ca&connectTimeout=10",
+        ) shouldBe
+            "postgresql://localhost:5432/orders?targetServerType=primary&connectTimeout=10"
+    }
+
+    test("does not remove consumed parameter names found inside values or longer names") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders" +
+                "?options=sslmode%3Drequire&mysslmode=prefer&schema=currentSchema",
+        ) shouldBe
+            "postgresql://localhost:5432/orders" +
+                "?options=sslmode%3Drequire&mysslmode=prefer&schema=currentSchema"
+    }
+
+    test("strips only the leading JDBC prefix when no query exists") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/jdbc:archive",
+        ) shouldBe "postgresql://localhost:5432/jdbc:archive"
+    }
+
+    test("preserves query parameters for non-PostgreSQL URLs") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:mysql://localhost:3306/orders?currentSchema=tenant&sslmode=require",
+        ) shouldBe "mysql://localhost:3306/orders?currentSchema=tenant&sslmode=require"
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
@@ -93,7 +93,7 @@ class HibernateReactiveAutoConfiguration(
     @Bean
     @ConditionalOnMissingBean(name = ["hibernateSessionFactory"])
     fun hibernateSessionFactory(): org.hibernate.SessionFactory {
-        val reactiveUrl = jdbcUrl.replace("jdbc:", "")
+        val reactiveUrl = ReactiveConnectionUrl.fromJdbc(jdbcUrl)
 
         val configuration =
             Configuration().apply {

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrl.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrl.kt
@@ -1,0 +1,36 @@
+package io.clroot.hibernate.reactive.spring.boot.autoconfigure
+
+internal object ReactiveConnectionUrl {
+    private val consumedParameters = setOf("sslmode", "currentSchema")
+    private val postgresSchemes = setOf("postgresql", "postgres")
+
+    fun fromJdbc(jdbcUrl: String): String {
+        val reactiveUrl = jdbcUrl.removePrefix("jdbc:")
+        if (reactiveUrl.substringBefore(':').lowercase() !in postgresSchemes) {
+            return reactiveUrl
+        }
+
+        val queryStart = reactiveUrl.indexOf('?')
+        if (queryStart < 0) {
+            return reactiveUrl
+        }
+
+        val baseUrl = reactiveUrl.substring(0, queryStart)
+        val queryAndFragment = reactiveUrl.substring(queryStart + 1)
+        val fragmentStart = queryAndFragment.indexOf('#')
+        val query = if (fragmentStart < 0) queryAndFragment else queryAndFragment.substring(0, fragmentStart)
+        val fragment = if (fragmentStart < 0) "" else queryAndFragment.substring(fragmentStart)
+        val retainedParameters = query
+            .split('&')
+            .filterNot { parameter -> parameter.substringBefore('=') in consumedParameters }
+
+        return buildString {
+            append(baseUrl)
+            if (retainedParameters.isNotEmpty()) {
+                append('?')
+                append(retainedParameters.joinToString("&"))
+            }
+            append(fragment)
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrlTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/ReactiveConnectionUrlTest.kt
@@ -1,0 +1,49 @@
+package io.clroot.hibernate.reactive.spring.boot.autoconfigure
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ReactiveConnectionUrlTest : FunSpec({
+
+    test("removes consumed SSL and schema parameters") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders" +
+                "?sslmode=verify-full&application_name=orders&currentSchema=tenant",
+        ) shouldBe "postgresql://localhost:5432/orders?application_name=orders"
+    }
+
+    test("removes the query delimiter when every parameter is consumed") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders?currentSchema=tenant&sslmode=require",
+        ) shouldBe "postgresql://localhost:5432/orders"
+    }
+
+    test("removes every duplicate consumed parameter and preserves unrelated parameters") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders" +
+                "?targetServerType=primary&sslmode=require&sslmode=verify-ca&connectTimeout=10",
+        ) shouldBe
+            "postgresql://localhost:5432/orders?targetServerType=primary&connectTimeout=10"
+    }
+
+    test("does not remove consumed parameter names found inside values or longer names") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/orders" +
+                "?options=sslmode%3Drequire&mysslmode=prefer&schema=currentSchema",
+        ) shouldBe
+            "postgresql://localhost:5432/orders" +
+                "?options=sslmode%3Drequire&mysslmode=prefer&schema=currentSchema"
+    }
+
+    test("strips only the leading JDBC prefix when no query exists") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:postgresql://localhost:5432/jdbc:archive",
+        ) shouldBe "postgresql://localhost:5432/jdbc:archive"
+    }
+
+    test("preserves query parameters for non-PostgreSQL URLs") {
+        ReactiveConnectionUrl.fromJdbc(
+            "jdbc:mysql://localhost:3306/orders?currentSchema=tenant&sslmode=require",
+        ) shouldBe "mysql://localhost:3306/orders?currentSchema=tenant&sslmode=require"
+    }
+})


### PR DESCRIPTION
## Summary

- remove PostgreSQL `sslmode` and `currentSchema` after translating them to Hibernate settings
- preserve unrelated URL parameters, ordering, values, duplicates, and fragments
- strip only the leading `jdbc:` prefix
- leave non-PostgreSQL query parameters unchanged
- add byte-identical Boot 3/4 URL regression tests and bilingual documentation

## Compatibility

Only the two PostgreSQL parameters already consumed by auto-configuration are removed. Other
database URLs and unrelated PostgreSQL connection parameters retain their previous values.
The helper is Kotlin-internal and the public API is unchanged.

## Verification

- TDD red: consumed parameters remained in the URL and path-local `jdbc:` text was removed
- core full suite: 31 tests, 0 failures
- Boot 3 full suite: 414 tests, 0 failures
- Boot 4 full suite: 389 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 URL implementation and tests: byte-identical
- exact-SHA standards review: passed
- exact-SHA specification review: passed
