### PR TITLE
docs: use the actual reactive property prefix

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -110,11 +110,12 @@ spring:
     url: jdbc:postgresql://localhost:5432/mydb
     username: user
     password: password
-
-kotlin:
-  hibernate:
-    reactive:
-      pool-size: 10
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate:
+        reactive:
+          pool-size: 10
 ```
 
 ## 문서

--- a/README.md
+++ b/README.md
@@ -162,11 +162,12 @@ spring:
     url: jdbc:postgresql://localhost:5432/mydb
     username: user
     password: password
-
-kotlin:
-  hibernate:
-    reactive:
-      pool-size: 10  # Connection pool size (default: 10)
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate:
+        reactive:
+          pool-size: 10  # Connection pool size (default: 10)
 ```
 
 ## Documentation

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/HibernateReactivePropertiesIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/HibernateReactivePropertiesIntegrationTest.kt
@@ -1,0 +1,21 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveProperties
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest(classes = [TestApplication::class])
+class HibernateReactivePropertiesIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var properties: HibernateReactiveProperties
+
+    init {
+        describe("Hibernate Reactive configuration properties") {
+            it("binds the pool size from the documented prefix") {
+                properties.poolSize shouldBe 5
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/resources/application-test.yml
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/resources/application-test.yml
@@ -9,11 +9,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
-kotlin:
-  hibernate:
-    reactive:
-      pool-size: 5
+        reactive:
+          pool-size: 5
 
 logging:
   level:

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/HibernateReactivePropertiesIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/HibernateReactivePropertiesIntegrationTest.kt
@@ -1,0 +1,21 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveProperties
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest(classes = [TestApplication::class])
+class HibernateReactivePropertiesIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var properties: HibernateReactiveProperties
+
+    init {
+        describe("Hibernate Reactive configuration properties") {
+            it("binds the pool size from the documented prefix") {
+                properties.poolSize shouldBe 5
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/resources/application-test.yml
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/resources/application-test.yml
@@ -7,11 +7,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
-kotlin:
-  hibernate:
-    reactive:
-      pool-size: 5
+        reactive:
+          pool-size: 5
 
 logging:
   level:


### PR DESCRIPTION
## Summary

- replace the nonexistent `kotlin.hibernate.reactive` README prefix with the actual Spring prefix
- add the required Hibernate dialect to the README quick-start configuration
- move Boot 3/4 test fixture pool size under `spring.jpa.properties.hibernate.reactive`
- add real Spring-context integration coverage proving `pool-size: 5` binds

## Verification

- focused Boot 3/4 binding integration tests: passed
- core full suite: 31 tests, 0 failures
- Boot 3 full suite: 415 tests, 0 failures
- Boot 4 full suite: 390 tests, 0 failures
- all-module `build -x test`: passed
- Boot 3/4 binding integration tests: byte-identical
- stale scoped prefix search: no matches
- exact-SHA standards review: passed
- exact-SHA specification review: passed
