### PR TITLE
ci: validate Maven release versions

### DIFF
--- a/.github/scripts/resolve-release-version.sh
+++ b/.github/scripts/resolve-release-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+event_name=${1:-}
+release_tag=${2:-}
+manual_version=${3:-}
+ref_type=${4:-}
+ref_name=${5:-}
+
+if [[ "$event_name" == "release" ]]; then
+  candidate=$release_tag
+elif [[ "$event_name" == "workflow_dispatch" ]]; then
+  candidate=$manual_version
+else
+  echo "Unsupported release event: '$event_name'" >&2
+  exit 1
+fi
+
+version=${candidate#v}
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+  echo "Invalid release version '$candidate'; expected a Maven-compatible semantic version" >&2
+  exit 1
+fi
+
+if [[ "$ref_type" == "tag" ]]; then
+  normalized_ref=${ref_name#v}
+  if [[ "$normalized_ref" != "$version" ]]; then
+    echo "Release version '$version' does not match checked-out tag '$ref_name'" >&2
+    exit 1
+  fi
+fi
+
+printf '%s\n' "$version"

--- a/.github/scripts/test-resolve-release-version.sh
+++ b/.github/scripts/test-resolve-release-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+resolver="$script_dir/resolve-release-version.sh"
+
+assert_output() {
+  local expected=$1
+  shift
+  local actual
+  actual=$(bash "$resolver" "$@")
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Expected '$expected' but got '$actual'" >&2
+    exit 1
+  fi
+}
+
+assert_failure() {
+  if bash "$resolver" "$@" >/dev/null 2>&1; then
+    echo "Expected version resolution to fail: $*" >&2
+    exit 1
+  fi
+}
+
+assert_output "1.2.3" release "1.2.3" "" tag "1.2.3"
+assert_output "1.2.3" release "v1.2.3" "" tag "v1.2.3"
+assert_output "2.0.0-RC1" workflow_dispatch "" "2.0.0-RC1" branch main
+assert_output "1.4.0" workflow_dispatch "" "1.4.0" tag "v1.4.0"
+
+assert_failure workflow_dispatch "" "" branch main
+assert_failure release "not-a-version" "" tag "not-a-version"
+assert_failure workflow_dispatch "" "1.2.3" tag "1.2.4"
+assert_failure push "" "1.2.3" branch main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Test release version resolver
+        run: bash .github/scripts/test-resolve-release-version.sh
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       version:
         description: "Version to publish (e.g., 1.0.0)"
-        required: false
+        required: true
         type: string
 
 jobs:
@@ -20,6 +20,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Resolve and validate release version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          version=$(bash .github/scripts/resolve-release-version.sh \
+            "$GITHUB_EVENT_NAME" "$RELEASE_TAG" "$MANUAL_VERSION" \
+            "$GITHUB_REF_TYPE" "$GITHUB_REF_NAME")
+          echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "ORG_GRADLE_PROJECT_releaseVersion=$version" >> "$GITHUB_ENV"
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            echo "ORG_GRADLE_PROJECT_releaseTag=$RELEASE_TAG" >> "$GITHUB_ENV"
+          fi
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -34,7 +48,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build and verify
-        run: ./gradlew build
+        run: ./gradlew validateReleaseVersion build
 
       - name: Publish to Maven Central
         run: ./gradlew publishAggregationToCentralPortal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,14 +6,58 @@ plugins {
     signing
 }
 
+val releaseVersion = providers.gradleProperty("releaseVersion")
+val releaseTag = providers.gradleProperty("releaseTag")
+val effectiveVersion = releaseVersion.orElse("1.0.0-SNAPSHOT")
+val releaseVersionPattern = Regex("""^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$""")
+val centralReleaseTaskNames = setOf(
+    "publishAllPublicationsToCentralPortal",
+    "publishAllPublicationsToNmcpRepository",
+    "nmcpPublishAllPublicationsToCentralPortal",
+    "nmcpPublishAggregationToCentralPortal",
+    "publishAggregationToCentralPortal",
+)
+
+val validateReleaseVersion by tasks.registering {
+    group = "verification"
+    description = "Validates the release version and its optional source tag."
+
+    doLast {
+        val versionToPublish = releaseVersion.orNull
+            ?: throw GradleException(
+                "releaseVersion is required for a Central release. " +
+                    "Pass -PreleaseVersion=<version> or ORG_GRADLE_PROJECT_releaseVersion.",
+            )
+
+        if (!releaseVersionPattern.matches(versionToPublish)) {
+            throw GradleException("Invalid releaseVersion '$versionToPublish'.")
+        }
+
+        releaseTag.orNull
+            ?.takeIf { it.isNotBlank() }
+            ?.removePrefix("v")
+            ?.let { normalizedTag ->
+                if (normalizedTag != versionToPublish) {
+                    throw GradleException(
+                        "releaseVersion '$versionToPublish' does not match releaseTag '${releaseTag.get()}'.",
+                    )
+                }
+            }
+    }
+}
+
 allprojects {
     apply(plugin = "maven-publish")
 
     group = "io.clroot"
-    version = "1.0.0"
+    version = effectiveVersion.get()
 
     repositories {
         mavenCentral()
+    }
+
+    tasks.matching { it.name in centralReleaseTaskNames }.configureEach {
+        dependsOn(rootProject.tasks.named("validateReleaseVersion"))
     }
 }
 


### PR DESCRIPTION
## Summary
- derive the Maven version from release tags or the required manual-dispatch input
- fail on missing, malformed, or tag-mismatched versions before any Central publishing task
- keep ordinary local builds on a safe `1.0.0-SNAPSHOT` default
- exercise the release resolver in CI

## Verification
- `bash .github/scripts/test-resolve-release-version.sh`
- `bash -n .github/scripts/resolve-release-version.sh .github/scripts/test-resolve-release-version.sh`
- parsed both workflow YAML files with Ruby/Psych
- `./gradlew clean test --no-build-cache`
- `./gradlew build -x test -PreleaseVersion=1.2.3 -PreleaseTag=1.2.3 --no-build-cache`
- verified missing and mismatched release versions fail
- verified all `nmcpPublishAllPublicationsToCentralPortal` tasks depend on `validateReleaseVersion`

## Review
- specification review: pass
- release/CI standards review: pass after closing the direct NMCP upload-task bypass