### PR TITLE
build: generate javadoc jars with Dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.spring) apply false
     alias(libs.plugins.kotlin.jpa) apply false
+    alias(libs.plugins.dokka) apply false
     `maven-publish`
     signing
 }
@@ -63,6 +64,7 @@ allprojects {
 
 subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "maven-publish")
     apply(plugin = "signing")
 
@@ -72,6 +74,34 @@ subprojects {
         }
         withSourcesJar()
         withJavadocJar()
+    }
+
+    val dokkaHtml = tasks.named("dokkaGeneratePublicationHtml")
+    val javadocJar = tasks.named<Jar>("javadocJar") {
+        dependsOn(dokkaHtml)
+        from(dokkaHtml.map { it.outputs.files })
+    }
+    val verifyJavadocJar by tasks.registering {
+        group = "verification"
+        description = "Verifies that the published javadoc JAR contains Dokka HTML."
+        dependsOn(javadocJar)
+        inputs.file(javadocJar.flatMap { it.archiveFile })
+
+        doLast(Action<Task> {
+            val archive = inputs.files.singleFile
+            val containsDocumentation = java.util.zip.ZipFile(archive).use { zip ->
+                zip.entries().asSequence().any { entry ->
+                    !entry.isDirectory && entry.name.endsWith(".html")
+                }
+            }
+            if (!containsDocumentation) {
+                throw GradleException("$path found an empty javadoc JAR: $archive")
+            }
+        })
+    }
+
+    tasks.named("check") {
+        dependsOn(verifyJavadocJar)
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "2.2.0"
+dokka = "2.2.0"
 coroutines = "1.10.2"
 hibernate-reactive = "3.1.0.Final"
 mutiny = "2.6.0"
@@ -49,3 +50,4 @@ scram-client = { module = "com.ongres.scram:scram-client", version = "3.2" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }


### PR DESCRIPTION
## Summary
- apply Dokka 2.2 to every published module
- populate the existing Maven `javadoc` variants from Dokka HTML output
- fail each module check when its javadoc JAR contains no HTML
- keep the verification action compatible with Gradle configuration cache

## Verification
- reproduced the old JARs containing only `META-INF/MANIFEST.MF`
- `./gradlew clean build --no-build-cache`
- `./gradlew verifyJavadocJar --configuration-cache --no-build-cache` twice (stored, then reused)
- core JAR: 32 HTML files; Boot 3/4 JARs: 147 HTML files each
- generated module metadata exposes each `javadocElements` artifact

## Review
- specification review: pass
- Dokka/Gradle standards review: pass