### PR TITLE
ci: attest core release artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,6 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
-            hibernate-reactive-coroutines/build/libs/*.jar
+            hibernate-reactive-coroutines-core/build/libs/*.jar
             hibernate-reactive-coroutines-spring-boot-starter/build/libs/*.jar
             hibernate-reactive-coroutines-spring-boot-starter-boot4/build/libs/*.jar


### PR DESCRIPTION
## Summary
- point SLSA provenance generation at the actual core module output directory
- retain attestation coverage for both Spring Boot starter modules

## Verification
- workflow YAML parses successfully
- old core glob: 0 matching JARs
- corrected core glob: 3 matching JARs
- Boot 3/4 starter globs: 4 matching JARs each

## Review
- specification review: pass
- GitHub attestation workflow review: pass