### PR TITLE
build: keep test fixtures out of publications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,52 @@ subprojects {
         withJavadocJar()
     }
 
+    pluginManager.withPlugin("java-test-fixtures") {
+        val javaComponent = components["java"] as org.gradle.api.component.AdhocComponentWithVariants
+        javaComponent.withVariantsFromConfiguration(configurations["testFixturesApiElements"]) {
+            skip()
+        }
+        javaComponent.withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) {
+            skip()
+        }
+
+        val verifyPublicationMetadata by tasks.registering {
+            group = "verification"
+            description = "Verifies that test fixtures do not leak into published metadata."
+            dependsOn(
+                "generatePomFileForMavenPublication",
+                "generateMetadataFileForMavenPublication",
+            )
+            inputs.files(
+                layout.buildDirectory.file("publications/maven/pom-default.xml"),
+                layout.buildDirectory.file("publications/maven/module.json"),
+            )
+
+            doLast(Action<Task> {
+                val leakedMarkers = listOf(
+                    "testFixturesApiElements",
+                    "testFixturesRuntimeElements",
+                    "-test-fixtures.jar",
+                    "spring-boot-starter-test",
+                    "io.kotest",
+                    "org.testcontainers",
+                )
+                inputs.files.forEach { metadataFile ->
+                    val metadata = metadataFile.readText()
+                    leakedMarkers.firstOrNull(metadata::contains)?.let { marker ->
+                        throw GradleException(
+                            "${metadataFile.name} exposes test-fixture marker '$marker'.",
+                        )
+                    }
+                }
+            })
+        }
+
+        tasks.named("check") {
+            dependsOn(verifyPublicationMetadata)
+        }
+    }
+
     val dokkaHtml = tasks.named("dokkaGeneratePublicationHtml")
     val javadocJar = tasks.named<Jar>("javadocJar") {
         dependsOn(dokkaHtml)


### PR DESCRIPTION
## Summary
- exclude Java test-fixture API/runtime variants from published starter components
- prevent Kotest, Testcontainers, and Spring test dependencies from appearing as optional POM dependencies
- verify generated POM and Gradle module metadata during each starter `check`
- retain local test fixture compilation and JARs for the project test suites

## Verification
- reproduced fixture variants and optional test dependencies in both starter publications
- `./gradlew verifyPublicationMetadata --no-build-cache`
- configuration cache stored and reused for the metadata verifier
- `./gradlew clean build --no-build-cache`
- generated Boot 3/4 POM and `.module` files contain no fixture/test markers

## Review
- specification review: pass
- Gradle publication standards review: pass