### PR TITLE
build: target the Java 17 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Test release version resolver
         run: bash .github/scripts/test-resolve-release-version.sh
 
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: "17"
           distribution: "temurin"
 
       - name: Setup Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,10 @@ jobs:
             echo "ORG_GRADLE_PROJECT_releaseTag=$RELEASE_TAG" >> "$GITHUB_ENV"
           fi
 
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: "17"
           distribution: "temurin"
 
       - name: Setup Gradle

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,6 +19,11 @@ Hibernate Reactive + Kotlin Coroutines 환경에서 Spring Data JPA의 편의성
 
 **Spring Data JPA 기능 커버리지: ~85-90%** - 자세한 내용은 [마이그레이션 가이드](docs/migration.ko.md)를 참고하세요.
 
+## 요구사항
+
+- Java 17 이상
+- Spring Boot 3.4.x 또는 4.x
+
 ## 설치
 
 ### Gradle (Kotlin DSL)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ This library provides a **Spring Boot starter for Hibernate Reactive** with firs
 
 **Spring Data JPA feature coverage: ~85-90%** — See [Migration Guide](docs/migration.md) for details.
 
+## Requirements
+
+- Java 17 or later
+- Spring Boot 3.4.x or 4.x
+
 ## Installation
 
 ### Gradle (Kotlin DSL)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,7 +107,7 @@ subprojects {
 
     configure<JavaPluginExtension> {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
         withSourcesJar()
         withJavadocJar()


### PR DESCRIPTION
## Summary
- compile and publish all modules against the Java 17 baseline
- run CI and publication workflows on Temurin 17
- document Java 17 and Spring Boot line requirements in both READMEs

## Verification
- `JAVA_HOME=...temurin-17.0.17... ./gradlew clean build --no-build-cache`
- main class files report Java class major version 61
- all published Gradle module metadata declares `org.gradle.jvm.version: 17`
- workflow YAML parses successfully
- independent specification and standards reviews: no findings