### PR TITLE
build: enforce public API compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.api whitespace=-blank-at-eof

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,6 +177,18 @@ subprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "signing")
 
+    configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
+        explicitApi()
+
+        @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+        extensions.configure<org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationExtension> {
+            enabled.set(true)
+        }
+    }
+    tasks.named("check") {
+        dependsOn("checkLegacyAbi")
+    }
+
     if (name in starterProjectNames) {
         configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
             sourceSets.named("main") {

--- a/hibernate-reactive-coroutines-core/api/hibernate-reactive-coroutines-core.api
+++ b/hibernate-reactive-coroutines-core/api/hibernate-reactive-coroutines-core.api
@@ -1,0 +1,51 @@
+public final class io/clroot/hibernate/reactive/ReactiveSessionContext : kotlin/coroutines/AbstractCoroutineContextElement {
+	public static final field Key Lio/clroot/hibernate/reactive/ReactiveSessionContext$Key;
+	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$Session;Lio/clroot/hibernate/reactive/TransactionMode;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$Session;Lio/clroot/hibernate/reactive/TransactionMode;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMode ()Lio/clroot/hibernate/reactive/TransactionMode;
+	public final fun getSession ()Lorg/hibernate/reactive/mutiny/Mutiny$Session;
+	public final fun getStartTimeNanos ()J
+	public final fun getTimeout-UwyO8pc ()J
+	public final fun isReadOnly ()Z
+	public final fun remainingTimeout-UwyO8pc ()J
+}
+
+public final class io/clroot/hibernate/reactive/ReactiveSessionContext$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+
+public final class io/clroot/hibernate/reactive/ReactiveSessionContextKt {
+	public static final fun currentContextOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun currentSessionOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/clroot/hibernate/reactive/ReactiveSessionProvider {
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public final fun read (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun write (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/clroot/hibernate/reactive/ReactiveTransactionExecutor {
+	public static final field Companion Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor$Companion;
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public final fun readOnly-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readOnly-KLykuaI$default (Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun transactional-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun transactional-KLykuaI$default (Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/clroot/hibernate/reactive/ReactiveTransactionExecutor$Companion {
+	public final fun getDEFAULT_TIMEOUT-UwyO8pc ()J
+}
+
+public final class io/clroot/hibernate/reactive/ReadOnlyTransactionException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/clroot/hibernate/reactive/TransactionMode : java/lang/Enum {
+	public static final field READ_ONLY Lio/clroot/hibernate/reactive/TransactionMode;
+	public static final field READ_WRITE Lio/clroot/hibernate/reactive/TransactionMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/clroot/hibernate/reactive/TransactionMode;
+	public static fun values ()[Lio/clroot/hibernate/reactive/TransactionMode;
+}
+

--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveSessionContext.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveSessionContext.kt
@@ -11,7 +11,7 @@ import kotlin.time.Duration.Companion.nanoseconds
 /**
  * 트랜잭션 모드
  */
-enum class TransactionMode {
+public enum class TransactionMode {
     READ_ONLY,
     READ_WRITE,
 }
@@ -27,15 +27,15 @@ enum class TransactionMode {
  * @param timeout 타임아웃 (기본값: 무제한)
  * @param startTimeNanos 시작 시간 (System.nanoTime() 기반, 시스템 시간 변경에 영향받지 않음)
  */
-class ReactiveSessionContext(
-    val session: Mutiny.Session,
-    val mode: TransactionMode,
-    val timeout: Duration = INFINITE,
-    val startTimeNanos: Long = System.nanoTime(),
+public class ReactiveSessionContext(
+    public val session: Mutiny.Session,
+    public val mode: TransactionMode,
+    public val timeout: Duration = INFINITE,
+    public val startTimeNanos: Long = System.nanoTime(),
 ) : AbstractCoroutineContextElement(ReactiveSessionContext) {
-    companion object Key : CoroutineContext.Key<ReactiveSessionContext>
+    public companion object Key : CoroutineContext.Key<ReactiveSessionContext>
 
-    val isReadOnly: Boolean get() = mode == TransactionMode.READ_ONLY
+    public val isReadOnly: Boolean get() = mode == TransactionMode.READ_ONLY
 
     /**
      * 남은 타임아웃 시간 계산.
@@ -44,7 +44,7 @@ class ReactiveSessionContext(
      * System.nanoTime()을 사용하여 시스템 시간 변경(NTP 동기화 등)에
      * 영향받지 않고 정확한 경과 시간을 측정합니다.
      */
-    fun remainingTimeout(): Duration {
+    public fun remainingTimeout(): Duration {
         if (timeout == INFINITE) return INFINITE
         val elapsedNanos = System.nanoTime() - startTimeNanos
         val remainingNanos = timeout.inWholeNanoseconds - elapsedNanos
@@ -56,12 +56,12 @@ class ReactiveSessionContext(
  * 현재 CoroutineContext에서 Session을 가져옵니다.
  * 컨텍스트가 없으면 null 반환.
  */
-suspend fun currentSessionOrNull(): Mutiny.Session? =
+public suspend fun currentSessionOrNull(): Mutiny.Session? =
     currentCoroutineContext()[ReactiveSessionContext]?.session
 
 /**
  * 현재 CoroutineContext에서 ReactiveSessionContext를 가져옵니다.
  * 컨텍스트가 없으면 null 반환.
  */
-suspend fun currentContextOrNull(): ReactiveSessionContext? =
+public suspend fun currentContextOrNull(): ReactiveSessionContext? =
     currentCoroutineContext()[ReactiveSessionContext]

--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveSessionProvider.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveSessionProvider.kt
@@ -7,7 +7,7 @@ import org.hibernate.reactive.mutiny.Mutiny
 /**
  * ReadOnly 컨텍스트에서 쓰기 시도 시 발생하는 예외
  */
-class ReadOnlyTransactionException(
+public class ReadOnlyTransactionException(
     message: String,
 ) : IllegalStateException(message)
 
@@ -36,7 +36,7 @@ class ReadOnlyTransactionException(
  * }
  * ```
  */
-class ReactiveSessionProvider(
+public class ReactiveSessionProvider(
     private val sessionFactory: Mutiny.SessionFactory,
 ) {
     /**
@@ -45,7 +45,7 @@ class ReactiveSessionProvider(
      * - 컨텍스트에 세션이 있으면 재사용
      * - 없으면 `withSession`으로 새 세션 생성
      */
-    suspend fun <T> read(block: (Mutiny.Session) -> Uni<T>): T {
+    public suspend fun <T> read(block: (Mutiny.Session) -> Uni<T>): T {
         val context = currentContextOrNull()
         return if (context != null) {
             block(context.session).awaitSuspending()
@@ -65,7 +65,7 @@ class ReactiveSessionProvider(
      *
      * @throws io.clroot.hibernate.reactive.ReadOnlyTransactionException readOnly 컨텍스트 내에서 호출 시
      */
-    suspend fun <T> write(block: (Mutiny.Session) -> Uni<T>): T {
+    public suspend fun <T> write(block: (Mutiny.Session) -> Uni<T>): T {
         val context = currentContextOrNull()
         return when {
             context?.isReadOnly == true -> {

--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
@@ -41,11 +41,11 @@ import kotlin.time.Duration.Companion.seconds
  * - 트랜잭션 내에서 외부 I/O(HTTP 호출 등)를 수행하면 DB 커넥션이 오래 점유됨
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ReactiveTransactionExecutor(
+public class ReactiveTransactionExecutor(
     private val sessionFactory: Mutiny.SessionFactory,
 ) {
-    companion object {
-        val DEFAULT_TIMEOUT: Duration = 30.seconds
+    public companion object {
+        public val DEFAULT_TIMEOUT: Duration = 30.seconds
     }
 
     /**
@@ -56,7 +56,7 @@ class ReactiveTransactionExecutor(
      *
      * @param timeout 트랜잭션 타임아웃 (기본 30초). 중첩 시 부모의 남은 시간과 비교하여 더 짧은 값 적용.
      */
-    suspend fun <T> transactional(
+    public suspend fun <T> transactional(
         timeout: Duration = DEFAULT_TIMEOUT,
         block: suspend () -> T,
     ): T = executeInSession(
@@ -75,7 +75,7 @@ class ReactiveTransactionExecutor(
      *
      * @param timeout 세션 타임아웃 (기본 30초). 중첩 시 부모의 남은 시간과 비교하여 더 짧은 값 적용.
      */
-    suspend fun <T> readOnly(
+    public suspend fun <T> readOnly(
         timeout: Duration = DEFAULT_TIMEOUT,
         block: suspend () -> T,
     ): T = executeInSession(

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/api/hibernate-reactive-coroutines-spring-boot-starter-boot4.api
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/api/hibernate-reactive-coroutines-spring-boot-starter-boot4.api
@@ -1,0 +1,259 @@
+public final class io/clroot/hibernate/reactive/spring/boot/auditing/AuditingEntityListener {
+	public fun <init> ()V
+	public final fun onPrePersist (Ljava/lang/Object;)V
+	public final fun onPreUpdate (Ljava/lang/Object;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler {
+	public fun <init> (Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditorAware;)V
+	public final fun hasAuditorAware ()Z
+	public final fun markCreated (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun markModified (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditorAware {
+	public abstract fun getCurrentAuditor (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAutoConfiguration {
+	public fun <init> ()V
+	public fun reactiveAuditingHandler (Lorg/springframework/beans/factory/ObjectProvider;)Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration {
+	public fun <init> (Lorg/springframework/context/ApplicationContext;Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/lang/Integer;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZ)V
+	public fun hibernateReactiveTransactionManager (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager;
+	public fun hibernateSessionFactory ()Lorg/hibernate/SessionFactory;
+	public fun reactiveSessionFactory (Lorg/hibernate/SessionFactory;)Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;
+	public fun reactiveSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveSessionProvider;
+	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun transactionalAwareSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties {
+	public fun <init> ()V
+	public fun <init> (ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;
+	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConnectTimeout ()Ljava/lang/Integer;
+	public final fun getIdleTimeout ()Ljava/lang/Integer;
+	public final fun getMaxWaitQueueSize ()Ljava/lang/Integer;
+	public final fun getPoolSize ()I
+	public final fun getSslMode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration$Companion;
+	public fun <init> ()V
+	public static final fun hibernateReactiveRepositoryRegistrar ()Lio/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration$Companion {
+	public final fun hibernateReactiveRepositoryRegistrar ()Lio/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration : org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration$Companion;
+	public fun <init> ()V
+	public fun configure (Ljava/util/Map;)V
+	public fun connectOptions (Ljava/net/URI;)Lio/vertx/sqlclient/SqlConnectOptions;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration$Companion {
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/EnableHibernateReactiveRepositories : java/lang/annotation/Annotation {
+	public abstract fun basePackageClasses ()[Ljava/lang/Class;
+	public abstract fun basePackages ()[Ljava/lang/String;
+	public abstract fun value ()[Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoriesRegistrarSelector : org/springframework/context/annotation/ImportBeanDefinitionRegistrar {
+	public fun <init> ()V
+	public fun registerBeanDefinitions (Lorg/springframework/core/type/AnnotationMetadata;Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBean : org/springframework/beans/factory/FactoryBean {
+	public field sessionProvider Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+	public field transactionExecutor Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun <init> (Ljava/lang/Class;)V
+	public final fun getAuditingHandler ()Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;
+	public synthetic fun getObject ()Ljava/lang/Object;
+	public fun getObject ()Lorg/springframework/data/repository/kotlin/CoroutineCrudRepository;
+	public fun getObjectType ()Ljava/lang/Class;
+	public final fun getSessionProvider ()Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+	public final fun getTransactionExecutor ()Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun isSingleton ()Z
+	public final fun setAuditingHandler (Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;)V
+	public final fun setSessionProvider (Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;)V
+	public final fun setTransactionExecutor (Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar : org/springframework/beans/factory/support/BeanDefinitionRegistryPostProcessor, org/springframework/context/ApplicationContextAware {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun postProcessBeanDefinitionRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+	public fun postProcessBeanFactory (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;)V
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository : java/lang/reflect/InvocationHandler {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository$Companion;
+	public fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;)V
+	public synthetic fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun invoke (Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository$Companion {
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying : java/lang/annotation/Annotation {
+	public abstract fun clearAutomatically ()Z
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/query/Param : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Companion;
+	public abstract fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Companion {
+	public final fun forType (Lorg/springframework/data/repository/query/parser/Part$Type;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Containing : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Containing;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Direct : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Direct;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$EndingWith : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$EndingWith;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$StartingWith : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$StartingWith;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle : java/lang/Enum {
+	public static final field NAMED Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static final field NONE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static final field POSITIONAL Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static fun values ()[Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod {
+	public fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/reflect/Method;
+	public final fun component10 ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component2 ()Lorg/springframework/data/repository/query/parser/PartTree;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountHql ()Ljava/lang/String;
+	public final fun getHql ()Ljava/lang/String;
+	public final fun getMethod ()Ljava/lang/reflect/Method;
+	public final fun getParameterBinders ()Ljava/util/List;
+	public final fun getParameterNames ()Ljava/util/List;
+	public final fun getParameterStyle ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public final fun getPartTree ()Lorg/springframework/data/repository/query/parser/PartTree;
+	public final fun getReturnType ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public fun hashCode ()I
+	public final fun isAnnotatedQuery ()Z
+	public final fun isModifying ()Z
+	public final fun isNativeQuery ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/query/Query : java/lang/annotation/Annotation {
+	public abstract fun countQuery ()Ljava/lang/String;
+	public abstract fun nativeQuery ()Z
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType : java/lang/Enum {
+	public static final field BOOLEAN Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field LIST Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field LONG Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field MODIFYING Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field PAGE Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field SINGLE Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field SLICE Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field VOID Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static fun values ()[Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager : org/springframework/transaction/reactive/AbstractReactiveTransactionManager, org/springframework/beans/factory/InitializingBean {
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public fun afterPropertiesSet ()V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/transaction/MutinySessionHolder : org/springframework/transaction/support/ResourceHolderSupport {
+	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$Session;Lio/vertx/core/Context;Lio/clroot/hibernate/reactive/TransactionMode;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$Session;Lio/vertx/core/Context;Lio/clroot/hibernate/reactive/TransactionMode;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getSession ()Lorg/hibernate/reactive/mutiny/Mutiny$Session;
+	public final fun getVertxContext ()Lio/vertx/core/Context;
+	public final fun hasSession ()Z
+	public final fun isTransactionActive ()Z
+	public fun released ()V
+	public final fun setSession (Lorg/hibernate/reactive/mutiny/Mutiny$Session;)V
+	public final fun setTransactionActive (Z)V
+	public final fun setVertxContext (Lio/vertx/core/Context;)V
+	public final fun toReactiveSessionContext ()Lio/clroot/hibernate/reactive/ReactiveSessionContext;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider {
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public fun fetch (Ljava/lang/Object;Lkotlin/reflect/KProperty1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchAll (Ljava/lang/Object;[Lkotlin/reflect/KProperty1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchFromDetached (Ljava/lang/Object;Ljava/lang/Class;Lkotlin/reflect/KProperty1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun read (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditingEntityListener.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditingEntityListener.kt
@@ -38,7 +38,7 @@ import jakarta.persistence.PreUpdate
  *
  * @see ReactiveAuditingHandler
  */
-class AuditingEntityListener {
+public class AuditingEntityListener {
 
     /**
      * 엔티티가 처음 저장되기 전에 호출됩니다.
@@ -46,7 +46,7 @@ class AuditingEntityListener {
      * `@CreatedDate`와 `@LastModifiedDate` 필드에 현재 시간을 설정합니다.
      */
     @PrePersist
-    fun onPrePersist(entity: Any) {
+    public fun onPrePersist(entity: Any) {
         AuditMetadata.setCreatedDate(entity)
         AuditMetadata.setLastModifiedDate(entity)
     }
@@ -57,7 +57,7 @@ class AuditingEntityListener {
      * `@LastModifiedDate` 필드에 현재 시간을 설정합니다.
      */
     @PreUpdate
-    fun onPreUpdate(entity: Any) {
+    public fun onPreUpdate(entity: Any) {
         AuditMetadata.setLastModifiedDate(entity)
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler.kt
@@ -12,7 +12,7 @@ package io.clroot.hibernate.reactive.spring.boot.auditing
  * @param T 감사자 타입
  * @param auditorAware 현재 감사자를 제공하는 인터페이스 (선택적)
  */
-class ReactiveAuditingHandler<T : Any>(
+public class ReactiveAuditingHandler<T : Any>(
     private val auditorAware: ReactiveAuditorAware<T>?,
 ) {
     /**
@@ -22,7 +22,7 @@ class ReactiveAuditingHandler<T : Any>(
      *
      * @param entity 감사자 정보를 설정할 엔티티
      */
-    suspend fun markCreated(entity: Any) {
+    public suspend fun markCreated(entity: Any) {
         auditorAware?.getCurrentAuditor()?.let { auditor ->
             AuditMetadata.setCreatedBy(entity, auditor)
             AuditMetadata.setLastModifiedBy(entity, auditor)
@@ -36,7 +36,7 @@ class ReactiveAuditingHandler<T : Any>(
      *
      * @param entity 감사자 정보를 설정할 엔티티
      */
-    suspend fun markModified(entity: Any) {
+    public suspend fun markModified(entity: Any) {
         auditorAware?.getCurrentAuditor()?.let { auditor ->
             AuditMetadata.setLastModifiedBy(entity, auditor)
         }
@@ -45,5 +45,5 @@ class ReactiveAuditingHandler<T : Any>(
     /**
      * AuditorAware가 설정되어 있는지 확인합니다.
      */
-    fun hasAuditorAware(): Boolean = auditorAware != null
+    public fun hasAuditorAware(): Boolean = auditorAware != null
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditorAware.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditorAware.kt
@@ -21,11 +21,11 @@ package io.clroot.hibernate.reactive.spring.boot.auditing
  *
  * @param T 감사자 타입 (일반적으로 String 또는 사용자 ID 타입)
  */
-fun interface ReactiveAuditorAware<T : Any> {
+public fun interface ReactiveAuditorAware<T : Any> {
     /**
      * 현재 감사자를 반환합니다.
      *
      * @return 현재 감사자 또는 null (익명 사용자인 경우)
      */
-    suspend fun getCurrentAuditor(): T?
+    public suspend fun getCurrentAuditor(): T?
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAutoConfiguration.kt
@@ -29,11 +29,11 @@ import org.springframework.context.annotation.Bean
  * 통해 처리됩니다. 엔티티에 `@EntityListeners(AuditingEntityListener::class)`를 추가해야 합니다.
  */
 @AutoConfiguration
-class AuditingAutoConfiguration {
+public class AuditingAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun reactiveAuditingHandler(
+    public fun reactiveAuditingHandler(
         auditorAware: ObjectProvider<ReactiveAuditorAware<*>>,
     ): ReactiveAuditingHandler<*> {
         return ReactiveAuditingHandler(auditorAware.getIfAvailable())

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
@@ -51,7 +51,7 @@ import org.springframework.core.type.filter.AnnotationTypeFilter
 @AutoConfiguration
 @ConditionalOnClass(Mutiny.SessionFactory::class)
 @EnableConfigurationProperties(HibernateReactiveProperties::class)
-class HibernateReactiveAutoConfiguration(
+public class HibernateReactiveAutoConfiguration(
     private val applicationContext: ApplicationContext,
     private val properties: HibernateReactiveProperties,
     // === 데이터소스 설정 ===
@@ -92,7 +92,7 @@ class HibernateReactiveAutoConfiguration(
 ) {
     @Bean
     @ConditionalOnMissingBean(name = ["hibernateSessionFactory"])
-    fun hibernateSessionFactory(): org.hibernate.SessionFactory {
+    public fun hibernateSessionFactory(): org.hibernate.SessionFactory {
         val reactiveUrl = ReactiveConnectionUrl.fromJdbc(jdbcUrl)
 
         val configuration =
@@ -251,27 +251,31 @@ class HibernateReactiveAutoConfiguration(
 
     @Bean
     @ConditionalOnMissingBean
-    fun reactiveSessionFactory(hibernateSessionFactory: org.hibernate.SessionFactory): Mutiny.SessionFactory =
+    public fun reactiveSessionFactory(hibernateSessionFactory: org.hibernate.SessionFactory): Mutiny.SessionFactory =
         hibernateSessionFactory.unwrap(Mutiny.SessionFactory::class.java)
 
     @Bean
     @ConditionalOnMissingBean
-    fun reactiveSessionProvider(sessionFactory: Mutiny.SessionFactory): ReactiveSessionProvider =
+    public fun reactiveSessionProvider(sessionFactory: Mutiny.SessionFactory): ReactiveSessionProvider =
         ReactiveSessionProvider(sessionFactory)
 
     @Bean
     @ConditionalOnMissingBean
-    fun reactiveTransactionExecutor(sessionFactory: Mutiny.SessionFactory): ReactiveTransactionExecutor =
+    public fun reactiveTransactionExecutor(sessionFactory: Mutiny.SessionFactory): ReactiveTransactionExecutor =
         ReactiveTransactionExecutor(sessionFactory)
 
     @Bean
     @ConditionalOnMissingBean
-    fun hibernateReactiveTransactionManager(reactiveSessionFactory: Mutiny.SessionFactory): HibernateReactiveTransactionManager =
+    public fun hibernateReactiveTransactionManager(
+        reactiveSessionFactory: Mutiny.SessionFactory,
+    ): HibernateReactiveTransactionManager =
         HibernateReactiveTransactionManager(reactiveSessionFactory)
 
     @Bean
     @ConditionalOnMissingBean
-    fun transactionalAwareSessionProvider(sessionFactory: Mutiny.SessionFactory): TransactionalAwareSessionProvider =
+    public fun transactionalAwareSessionProvider(
+        sessionFactory: Mutiny.SessionFactory,
+    ): TransactionalAwareSessionProvider =
         TransactionalAwareSessionProvider(sessionFactory)
 
     private fun findEntityClasses(basePackages: List<String>): List<Class<*>> {

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * ```
  */
 @ConfigurationProperties(prefix = "spring.jpa.properties.hibernate.reactive")
-data class HibernateReactiveProperties(
+public data class HibernateReactiveProperties(
     /**
      * Hibernate Reactive 커넥션 풀 사이즈 (기본값: 10)
      *

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration.kt
@@ -14,9 +14,9 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
  */
 @AutoConfiguration(after = [HibernateReactiveAutoConfiguration::class])
 @ConditionalOnClass(CoroutineCrudRepository::class)
-class HibernateReactiveRepositoryAutoConfiguration {
+public class HibernateReactiveRepositoryAutoConfiguration {
 
-    companion object {
+    public companion object {
         /**
          * static 메서드로 BeanDefinitionRegistryPostProcessor를 등록해야
          * Spring이 이른 시점에 처리할 수 있습니다.
@@ -24,7 +24,7 @@ class HibernateReactiveRepositoryAutoConfiguration {
         @Bean
         @ConditionalOnMissingBean
         @JvmStatic
-        fun hibernateReactiveRepositoryRegistrar(): HibernateReactiveRepositoryRegistrar {
+        public fun hibernateReactiveRepositoryRegistrar(): HibernateReactiveRepositoryRegistrar {
             return HibernateReactiveRepositoryRegistrar()
         }
     }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration.kt
@@ -12,9 +12,9 @@ import java.net.URI
  * PostgreSQL 연결 시 SSL 모드를 적용합니다.
  * `vertx-pg-client` 의존성이 없어도 동작하도록 Reflection을 사용합니다.
  */
-class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
+public class SslAwareSqlClientPoolConfiguration : DefaultSqlClientPoolConfiguration() {
 
-    companion object {
+    public companion object {
         private const val SSL_MODE_PROPERTY = "hibernate.vertx.pool.ssl.mode"
         private const val TRUST_CERTIFICATE_PROPERTY = "hibernate.vertx.pool.ssl.trust-certificate"
         private const val PG_CONNECT_OPTIONS_CLASS = "io.vertx.pgclient.PgConnectOptions"

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EnableHibernateReactiveRepositories.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/EnableHibernateReactiveRepositories.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
 @Import(HibernateReactiveRepositoriesRegistrarSelector::class)
-annotation class EnableHibernateReactiveRepositories(
+public annotation class EnableHibernateReactiveRepositories(
     /**
      * 스캔할 베이스 패키지 (basePackages의 별칭)
      */

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoriesRegistrarSelector.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoriesRegistrarSelector.kt
@@ -8,7 +8,7 @@ import org.springframework.core.type.AnnotationMetadata
 /**
  * @EnableHibernateReactiveRepositories 어노테이션을 처리하여 적절한 Registrar를 선택합니다.
  */
-class HibernateReactiveRepositoriesRegistrarSelector : ImportBeanDefinitionRegistrar {
+public class HibernateReactiveRepositoriesRegistrarSelector : ImportBeanDefinitionRegistrar {
 
     override fun registerBeanDefinitions(
         importingClassMetadata: AnnotationMetadata,

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBean.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBean.kt
@@ -20,18 +20,18 @@ import java.lang.reflect.Proxy
  * @param T Repository 인터페이스 타입
  * @param repositoryInterface Repository 인터페이스 클래스
  */
-class HibernateReactiveRepositoryFactoryBean<T : CoroutineCrudRepository<*, *>>(
+public class HibernateReactiveRepositoryFactoryBean<T : CoroutineCrudRepository<*, *>>(
     private val repositoryInterface: Class<T>,
 ) : FactoryBean<T> {
 
     @Autowired
-    lateinit var sessionProvider: TransactionalAwareSessionProvider
+    public lateinit var sessionProvider: TransactionalAwareSessionProvider
 
     @Autowired
-    lateinit var transactionExecutor: ReactiveTransactionExecutor
+    public lateinit var transactionExecutor: ReactiveTransactionExecutor
 
     @Autowired(required = false)
-    var auditingHandler: ReactiveAuditingHandler<*>? = null
+    public var auditingHandler: ReactiveAuditingHandler<*>? = null
 
     @Suppress("UNCHECKED_CAST")
     override fun getObject(): T {

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar.kt
@@ -18,7 +18,7 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
  *
  * @param basePackages 스캔할 베이스 패키지 (비어있으면 @SpringBootApplication 패키지 사용)
  */
-class HibernateReactiveRepositoryRegistrar(
+public class HibernateReactiveRepositoryRegistrar(
     private val basePackages: List<String> = emptyList(),
 ) : BeanDefinitionRegistryPostProcessor, ApplicationContextAware {
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
@@ -33,7 +33,7 @@ import kotlin.coroutines.startCoroutine
  * @param sessionProvider ReactiveSessionProvider 인스턴스
  * @param queryMethods 미리 파싱된 쿼리 메서드 맵
  */
-class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
+public class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
     private val entityClass: Class<T>,
     private val idClass: Class<ID>,
     private val sessionProvider: TransactionalAwareSessionProvider,
@@ -42,7 +42,7 @@ class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
     auditingHandler: ReactiveAuditingHandler<*>? = null,
 ) : InvocationHandler {
 
-    companion object {
+    public companion object {
         /** CoroutineCrudRepository의 기본 메서드 이름들 */
         private val BASE_METHODS = setOf(
             "save", "saveAll",

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying.kt
@@ -8,6 +8,6 @@ package io.clroot.hibernate.reactive.spring.boot.repository.query
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Modifying(
+public annotation class Modifying(
     val clearAutomatically: Boolean = false,
 )

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Param.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Param.kt
@@ -8,4 +8,4 @@ package io.clroot.hibernate.reactive.spring.boot.repository.query
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Param(val value: String)
+public annotation class Param(val value: String)

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder.kt
@@ -8,46 +8,46 @@ import org.springframework.data.repository.query.parser.Part
  * Part.Type에 따라 파라미터 값을 변환합니다.
  * 예: CONTAINING → "%value%", STARTING_WITH → "value%"
  */
-sealed class ParameterBinder {
+public sealed class ParameterBinder {
 
     /**
      * 파라미터 값을 바인딩에 적합한 형태로 변환합니다.
      */
-    abstract fun bind(value: Any?): Any?
+    public abstract fun bind(value: Any?): Any?
 
     /**
      * 기본 바인더 - 값을 그대로 전달
      */
-    data object Direct : ParameterBinder() {
+    public data object Direct : ParameterBinder() {
         override fun bind(value: Any?): Any? = value
     }
 
     /**
      * LIKE 패턴 바인더 - 값 양쪽에 % 추가
      */
-    data object Containing : ParameterBinder() {
+    public data object Containing : ParameterBinder() {
         override fun bind(value: Any?): Any? = value?.let { "%$it%" }
     }
 
     /**
      * StartingWith 패턴 바인더 - 값 뒤에 % 추가
      */
-    data object StartingWith : ParameterBinder() {
+    public data object StartingWith : ParameterBinder() {
         override fun bind(value: Any?): Any? = value?.let { "$it%" }
     }
 
     /**
      * EndingWith 패턴 바인더 - 값 앞에 % 추가
      */
-    data object EndingWith : ParameterBinder() {
+    public data object EndingWith : ParameterBinder() {
         override fun bind(value: Any?): Any? = value?.let { "%$it" }
     }
 
-    companion object {
+    public companion object {
         /**
          * Part.Type에 맞는 ParameterBinder를 반환합니다.
          */
-        fun forType(type: Part.Type): ParameterBinder = when (type) {
+        public fun forType(type: Part.Type): ParameterBinder = when (type) {
             Part.Type.CONTAINING, Part.Type.NOT_CONTAINING -> Containing
             Part.Type.STARTING_WITH -> StartingWith
             Part.Type.ENDING_WITH -> EndingWith

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle.kt
@@ -3,7 +3,7 @@ package io.clroot.hibernate.reactive.spring.boot.repository.query
 /**
  * 파라미터 바인딩 스타일.
  */
-enum class ParameterStyle {
+public enum class ParameterStyle {
     /** Named Parameter (:name) */
     NAMED,
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
@@ -20,7 +20,7 @@ import java.lang.reflect.Method
  * @param parameterStyle 파라미터 바인딩 스타일 (NAMED, POSITIONAL, NONE)
  * @param parameterNames Named Parameter 사용 시 파라미터 이름 목록
  */
-data class PreparedQueryMethod(
+public data class PreparedQueryMethod(
     val method: Method,
     val partTree: PartTree?,
     val hql: String,

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Query.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/Query.kt
@@ -9,7 +9,7 @@ package io.clroot.hibernate.reactive.spring.boot.repository.query
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Query(
+public annotation class Query(
     val value: String,
     val nativeQuery: Boolean = false,
     val countQuery: String = "",

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType.kt
@@ -3,7 +3,7 @@ package io.clroot.hibernate.reactive.spring.boot.repository.query
 /**
  * 쿼리 메서드의 반환 타입.
  */
-enum class QueryReturnType {
+public enum class QueryReturnType {
     /** 단일 엔티티 (nullable) */
     SINGLE,
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
@@ -29,7 +29,7 @@ import kotlin.time.toKotlinDuration
  * 이 트랜잭션 매니저는 [ReactiveSessionContext]와 통합되어,
  * @Transactional 컨텍스트 내에서 Repository가 자동으로 현재 세션을 인식합니다.
  */
-class HibernateReactiveTransactionManager(
+public class HibernateReactiveTransactionManager(
     private val sessionFactory: Mutiny.SessionFactory,
 ) : AbstractReactiveTransactionManager(), InitializingBean {
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/MutinySessionHolder.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/MutinySessionHolder.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration
  * Mutiny.Session을 래핑하여 Spring TransactionSynchronizationManager에서 관리할 수 있도록 합니다.
  * Vert.x Context와 트랜잭션 메타데이터도 함께 저장하여 [ReactiveSessionContext]와 통합합니다.
  */
-class MutinySessionHolder(
+public class MutinySessionHolder(
     private var session: Mutiny.Session?,
     private var vertxContext: Context? = null,
     private val mode: TransactionMode = TransactionMode.READ_WRITE,
@@ -23,19 +23,19 @@ class MutinySessionHolder(
 
     private var transactionActive: Boolean = false
 
-    fun getSession(): Mutiny.Session {
+    public fun getSession(): Mutiny.Session {
         return session ?: throw IllegalStateException("No Mutiny.Session available")
     }
 
-    fun hasSession(): Boolean = session != null
+    public fun hasSession(): Boolean = session != null
 
-    fun setSession(session: Mutiny.Session?) {
+    public fun setSession(session: Mutiny.Session?) {
         this.session = session
     }
 
-    fun getVertxContext(): Context? = vertxContext
+    public fun getVertxContext(): Context? = vertxContext
 
-    fun setVertxContext(context: Context?) {
+    public fun setVertxContext(context: Context?) {
         this.vertxContext = context
     }
 
@@ -43,21 +43,21 @@ class MutinySessionHolder(
      * 세션 작업에 사용할 CoroutineDispatcher를 반환합니다.
      * Vert.x Context가 있으면 해당 dispatcher를, 없으면 null을 반환합니다.
      */
-    fun getDispatcher(): CoroutineDispatcher? {
+    public fun getDispatcher(): CoroutineDispatcher? {
         return vertxContext?.dispatcher()
     }
 
-    fun setTransactionActive(active: Boolean) {
+    public fun setTransactionActive(active: Boolean) {
         this.transactionActive = active
     }
 
-    fun isTransactionActive(): Boolean = transactionActive
+    public fun isTransactionActive(): Boolean = transactionActive
 
     /**
      * 현재 세션 홀더에서 ReactiveSessionContext를 생성합니다.
      * 코루틴 컨텍스트에 세션을 전파할 때 사용합니다.
      */
-    fun toReactiveSessionContext(): ReactiveSessionContext {
+    public fun toReactiveSessionContext(): ReactiveSessionContext {
         return ReactiveSessionContext(
             session = getSession(),
             mode = mode,

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider.kt
@@ -32,7 +32,7 @@ import kotlin.reflect.KProperty1
  * }
  * ```
  */
-open class TransactionalAwareSessionProvider(
+public open class TransactionalAwareSessionProvider(
     private val sessionFactory: Mutiny.SessionFactory,
 ) {
     internal val metamodel
@@ -45,7 +45,7 @@ open class TransactionalAwareSessionProvider(
      * - ReactiveSessionContext에 세션이 있으면 재사용
      * - 없으면 withSession으로 새 세션 생성
      */
-    open suspend fun <T> read(block: (Mutiny.Session) -> Uni<T>): T {
+    public open suspend fun <T> read(block: (Mutiny.Session) -> Uni<T>): T {
         // 1. @Transactional 컨텍스트 확인
         val transactionalContext = getTransactionalSessionContext()
         if (transactionalContext != null) {
@@ -76,7 +76,7 @@ open class TransactionalAwareSessionProvider(
      *
      * @throws ReadOnlyTransactionException readOnly 컨텍스트 내에서 호출 시
      */
-    open suspend fun <T> write(block: (Mutiny.Session) -> Uni<T>): T {
+    public open suspend fun <T> write(block: (Mutiny.Session) -> Uni<T>): T {
         // 1. @Transactional 컨텍스트 확인
         val transactionalContext = getTransactionalSessionContext()
         if (transactionalContext != null) {
@@ -174,7 +174,7 @@ open class TransactionalAwareSessionProvider(
      * @param property fetch할 연관관계 프로퍼티
      * @return fetch된 연관관계 컬렉션/엔티티
      */
-    open suspend fun <E : Any, T> fetch(entity: E, property: KProperty1<E, T>): T {
+    public open suspend fun <E : Any, T> fetch(entity: E, property: KProperty1<E, T>): T {
         return read { session ->
             val association = property.get(entity)
             session.fetch(association)
@@ -202,7 +202,7 @@ open class TransactionalAwareSessionProvider(
      * @param entity fetch할 연관관계들을 가진 엔티티
      * @param properties fetch할 연관관계 프로퍼티들
      */
-    open suspend fun <E : Any> fetchAll(entity: E, vararg properties: KProperty1<E, *>) {
+    public open suspend fun <E : Any> fetchAll(entity: E, vararg properties: KProperty1<E, *>) {
         read { session ->
             var chain: Uni<*> = Uni.createFrom().voidItem()
             for (property in properties) {
@@ -236,7 +236,7 @@ open class TransactionalAwareSessionProvider(
      * @param property fetch할 연관관계 프로퍼티
      * @return fetch된 연관관계 컬렉션/엔티티
      */
-    open suspend fun <E : Any, T> fetchFromDetached(
+    public open suspend fun <E : Any, T> fetchFromDetached(
         entity: E,
         entityClass: Class<E>,
         property: KProperty1<E, T>,

--- a/hibernate-reactive-coroutines-spring-boot-starter/api/hibernate-reactive-coroutines-spring-boot-starter.api
+++ b/hibernate-reactive-coroutines-spring-boot-starter/api/hibernate-reactive-coroutines-spring-boot-starter.api
@@ -1,0 +1,259 @@
+public final class io/clroot/hibernate/reactive/spring/boot/auditing/AuditingEntityListener {
+	public fun <init> ()V
+	public final fun onPrePersist (Ljava/lang/Object;)V
+	public final fun onPreUpdate (Ljava/lang/Object;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler {
+	public fun <init> (Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditorAware;)V
+	public final fun hasAuditorAware ()Z
+	public final fun markCreated (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun markModified (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditorAware {
+	public abstract fun getCurrentAuditor (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAutoConfiguration {
+	public fun <init> ()V
+	public fun reactiveAuditingHandler (Lorg/springframework/beans/factory/ObjectProvider;)Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration {
+	public fun <init> (Lorg/springframework/context/ApplicationContext;Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/lang/Integer;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZ)V
+	public fun hibernateReactiveTransactionManager (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager;
+	public fun hibernateSessionFactory ()Lorg/hibernate/SessionFactory;
+	public fun reactiveSessionFactory (Lorg/hibernate/SessionFactory;)Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;
+	public fun reactiveSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveSessionProvider;
+	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun transactionalAwareSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties {
+	public fun <init> ()V
+	public fun <init> (ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;
+	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConnectTimeout ()Ljava/lang/Integer;
+	public final fun getIdleTimeout ()Ljava/lang/Integer;
+	public final fun getMaxWaitQueueSize ()Ljava/lang/Integer;
+	public final fun getPoolSize ()I
+	public final fun getSslMode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration$Companion;
+	public fun <init> ()V
+	public static final fun hibernateReactiveRepositoryRegistrar ()Lio/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveRepositoryAutoConfiguration$Companion {
+	public final fun hibernateReactiveRepositoryRegistrar ()Lio/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration : org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration$Companion;
+	public fun <init> ()V
+	public fun configure (Ljava/util/Map;)V
+	public fun connectOptions (Ljava/net/URI;)Lio/vertx/sqlclient/SqlConnectOptions;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/pool/SslAwareSqlClientPoolConfiguration$Companion {
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/EnableHibernateReactiveRepositories : java/lang/annotation/Annotation {
+	public abstract fun basePackageClasses ()[Ljava/lang/Class;
+	public abstract fun basePackages ()[Ljava/lang/String;
+	public abstract fun value ()[Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoriesRegistrarSelector : org/springframework/context/annotation/ImportBeanDefinitionRegistrar {
+	public fun <init> ()V
+	public fun registerBeanDefinitions (Lorg/springframework/core/type/AnnotationMetadata;Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBean : org/springframework/beans/factory/FactoryBean {
+	public field sessionProvider Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+	public field transactionExecutor Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun <init> (Ljava/lang/Class;)V
+	public final fun getAuditingHandler ()Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;
+	public synthetic fun getObject ()Ljava/lang/Object;
+	public fun getObject ()Lorg/springframework/data/repository/kotlin/CoroutineCrudRepository;
+	public fun getObjectType ()Ljava/lang/Class;
+	public final fun getSessionProvider ()Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+	public final fun getTransactionExecutor ()Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun isSingleton ()Z
+	public final fun setAuditingHandler (Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;)V
+	public final fun setSessionProvider (Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;)V
+	public final fun setTransactionExecutor (Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar : org/springframework/beans/factory/support/BeanDefinitionRegistryPostProcessor, org/springframework/context/ApplicationContextAware {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun postProcessBeanDefinitionRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+	public fun postProcessBeanFactory (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;)V
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository : java/lang/reflect/InvocationHandler {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository$Companion;
+	public fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;)V
+	public synthetic fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun invoke (Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository$Companion {
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/query/Modifying : java/lang/annotation/Annotation {
+	public abstract fun clearAutomatically ()Z
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/query/Param : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Companion;
+	public abstract fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Companion {
+	public final fun forType (Lorg/springframework/data/repository/query/parser/Part$Type;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Containing : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Containing;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Direct : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$Direct;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$EndingWith : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$EndingWith;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$StartingWith : io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder {
+	public static final field INSTANCE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder$StartingWith;
+	public fun bind (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle : java/lang/Enum {
+	public static final field NAMED Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static final field NONE Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static final field POSITIONAL Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public static fun values ()[Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod {
+	public fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/reflect/Method;
+	public final fun component10 ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component2 ()Lorg/springframework/data/repository/query/parser/PartTree;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountHql ()Ljava/lang/String;
+	public final fun getHql ()Ljava/lang/String;
+	public final fun getMethod ()Ljava/lang/reflect/Method;
+	public final fun getParameterBinders ()Ljava/util/List;
+	public final fun getParameterNames ()Ljava/util/List;
+	public final fun getParameterStyle ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
+	public final fun getPartTree ()Lorg/springframework/data/repository/query/parser/PartTree;
+	public final fun getReturnType ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public fun hashCode ()I
+	public final fun isAnnotatedQuery ()Z
+	public final fun isModifying ()Z
+	public final fun isNativeQuery ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface annotation class io/clroot/hibernate/reactive/spring/boot/repository/query/Query : java/lang/annotation/Annotation {
+	public abstract fun countQuery ()Ljava/lang/String;
+	public abstract fun nativeQuery ()Z
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType : java/lang/Enum {
+	public static final field BOOLEAN Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field LIST Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field LONG Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field MODIFYING Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field PAGE Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field SINGLE Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field SLICE Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static final field VOID Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+	public static fun values ()[Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager : org/springframework/transaction/reactive/AbstractReactiveTransactionManager, org/springframework/beans/factory/InitializingBean {
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public fun afterPropertiesSet ()V
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/transaction/MutinySessionHolder : org/springframework/transaction/support/ResourceHolderSupport {
+	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$Session;Lio/vertx/core/Context;Lio/clroot/hibernate/reactive/TransactionMode;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$Session;Lio/vertx/core/Context;Lio/clroot/hibernate/reactive/TransactionMode;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getSession ()Lorg/hibernate/reactive/mutiny/Mutiny$Session;
+	public final fun getVertxContext ()Lio/vertx/core/Context;
+	public final fun hasSession ()Z
+	public final fun isTransactionActive ()Z
+	public fun released ()V
+	public final fun setSession (Lorg/hibernate/reactive/mutiny/Mutiny$Session;)V
+	public final fun setTransactionActive (Z)V
+	public final fun setVertxContext (Lio/vertx/core/Context;)V
+	public final fun toReactiveSessionContext ()Lio/clroot/hibernate/reactive/ReactiveSessionContext;
+}
+
+public class io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider {
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public fun fetch (Ljava/lang/Object;Lkotlin/reflect/KProperty1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchAll (Ljava/lang/Object;[Lkotlin/reflect/KProperty1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetchFromDetached (Ljava/lang/Object;Ljava/lang/Class;Lkotlin/reflect/KProperty1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun read (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+


### PR DESCRIPTION
## Summary
- compile every published module in Kotlin strict explicit API mode
- enable Kotlin 2.2 built-in binary compatibility validation for all modules
- commit the current ABI baselines and wire every module check to enforce them
- preserve the existing public Kotlin/JVM API while making its visibility explicit

## Verification
- Temurin 17 `./gradlew clean build --no-build-cache` (52 tasks)
- all three `checkLegacyAbi` tasks pass and are present in `check --dry-run`
- forced ABI regeneration matches tracked dumps byte-for-byte
- Boot 3 and Boot 4 ABI dumps are identical
- `check --configuration-cache` stores and reuses cache
- independent specification and standards reviews: no findings