### PR TITLE
Apply Spring transaction isolation levels

### DIFF
--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionIsolationConfigurerTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionIsolationConfigurerTest.kt
@@ -1,0 +1,187 @@
+package io.clroot.hibernate.reactive.spring.boot.transaction
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.vertx.sqlclient.spi.DatabaseMetadata
+import org.hibernate.reactive.pool.ReactiveConnection
+import org.springframework.transaction.InvalidIsolationLevelException
+import org.springframework.transaction.TransactionDefinition
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+class TransactionIsolationConfigurerTest : DescribeSpec({
+
+    fun completedVoid(): CompletionStage<Void> = CompletableFuture.completedFuture(null)
+
+    fun connection(productName: String, events: MutableList<String>): ReactiveConnection {
+        val metadata = mockk<DatabaseMetadata>()
+        val connection = mockk<ReactiveConnection>()
+        val isolationResult = mockk<ReactiveConnection.Result>()
+
+        every { metadata.productName() } returns productName
+        every { connection.databaseMetadata } returns metadata
+        every { isolationResult.hasNext() } returns true
+        every { isolationResult.next() } returns arrayOf("READ-COMMITTED")
+        every { connection.select(any()) } answers {
+            events += firstArg<String>()
+            CompletableFuture.completedFuture(isolationResult)
+        }
+        every { connection.beginTransaction() } answers {
+            events += "begin"
+            completedVoid()
+        }
+        every { connection.executeUnprepared(any()) } answers {
+            events += firstArg<String>()
+            completedVoid()
+        }
+        every { connection.rollbackTransaction() } answers {
+            events += "rollback"
+            completedVoid()
+        }
+
+        return connection
+    }
+
+    describe("transaction isolation configuration") {
+        it("begins directly when the database default is requested") {
+            val events = mutableListOf<String>()
+            val connection = connection("unknown", events)
+
+            TransactionIsolationConfigurer.begin(
+                connection,
+                TransactionDefinition.ISOLATION_DEFAULT,
+            ).await().indefinitely()
+
+            events shouldContainExactly listOf("begin")
+        }
+
+        it("configures PostgreSQL after beginning the transaction") {
+            val events = mutableListOf<String>()
+            val connection = connection("PostgreSQL", events)
+
+            TransactionIsolationConfigurer.begin(
+                connection,
+                TransactionDefinition.ISOLATION_REPEATABLE_READ,
+            ).await().indefinitely()
+
+            events shouldContainExactly
+                listOf("begin", "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        }
+
+        it("configures MySQL and MariaDB before beginning the transaction") {
+            listOf("MySQL", "MariaDB").forEach { productName ->
+                val events = mutableListOf<String>()
+                val connection = connection(productName, events)
+
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_SERIALIZABLE,
+                ).await().indefinitely()
+
+                events shouldContainExactly
+                    listOf(
+                        "SELECT @@SESSION.transaction_isolation",
+                        "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+                        "begin",
+                    )
+            }
+        }
+
+        it("restores the MySQL session isolation when begin fails") {
+            val events = mutableListOf<String>()
+            val connection = connection("MySQL", events)
+            every { connection.beginTransaction() } answers {
+                events += "begin"
+                CompletableFuture.failedFuture(IllegalStateException("begin failed"))
+            }
+
+            shouldThrow<IllegalStateException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_SERIALIZABLE,
+                ).await().indefinitely()
+            }.message shouldBe "begin failed"
+
+            events shouldContainExactly
+                listOf(
+                    "SELECT @@SESSION.transaction_isolation",
+                    "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+                    "begin",
+                    "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+                )
+        }
+
+        it("restores the MySQL session isolation when begin throws synchronously") {
+            val events = mutableListOf<String>()
+            val connection = connection("MySQL", events)
+            every { connection.beginTransaction() } answers {
+                events += "begin"
+                throw IllegalStateException("transaction already active")
+            }
+
+            shouldThrow<IllegalStateException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_REPEATABLE_READ,
+                ).await().indefinitely()
+            }.message shouldBe "transaction already active"
+
+            events shouldContainExactly
+                listOf(
+                    "SELECT @@SESSION.transaction_isolation",
+                    "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+                    "begin",
+                    "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+                )
+        }
+
+        it("rolls back PostgreSQL when applying isolation fails after begin") {
+            val events = mutableListOf<String>()
+            val connection = connection("PostgreSQL", events)
+            every { connection.executeUnprepared(any()) } answers {
+                events += firstArg<String>()
+                CompletableFuture.failedFuture(IllegalStateException("isolation failed"))
+            }
+
+            shouldThrow<IllegalStateException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_SERIALIZABLE,
+                ).await().indefinitely()
+            }.message shouldBe "isolation failed"
+
+            events shouldContainExactly
+                listOf("begin", "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE", "rollback")
+        }
+
+        it("rejects explicit isolation for unsupported databases") {
+            val events = mutableListOf<String>()
+            val connection = connection("Oracle", events)
+
+            shouldThrow<InvalidIsolationLevelException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_READ_COMMITTED,
+                ).await().indefinitely()
+            }
+
+            events shouldContainExactly emptyList()
+        }
+
+        it("rejects unknown Spring isolation constants") {
+            val events = mutableListOf<String>()
+            val connection = connection("PostgreSQL", events)
+            val result = TransactionIsolationConfigurer.begin(connection, Int.MAX_VALUE)
+
+            shouldThrow<InvalidIsolationLevelException> {
+                result.await().indefinitely()
+            }
+
+            events shouldContainExactly emptyList()
+        }
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionIsolationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionIsolationTest.kt
@@ -1,6 +1,7 @@
 package io.clroot.hibernate.reactive.test
 
 import io.clroot.hibernate.reactive.test.service.PropagationTestService
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.nulls.shouldNotBeNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -16,9 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest
  * - 기본값은 Isolation.DEFAULT (데이터베이스 기본값 사용)
  * - 지원 레벨: READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE
  *
- * ## 현재 구현
- * - Hibernate Reactive는 데이터베이스의 기본 isolation을 사용
- * - isolation 설정이 예외 없이 적용되고 트랜잭션이 정상 동작하는지 검증
+ * 각 트랜잭션 안에서 PostgreSQL의 실제 isolation 값을 조회하여 선언한 수준이 적용됐는지 검증합니다.
  */
 @SpringBootTest(classes = [TestApplication::class, PropagationTestService::class])
 class TransactionIsolationTest : IntegrationTestBase() {
@@ -29,27 +28,30 @@ class TransactionIsolationTest : IntegrationTestBase() {
     init {
         describe("Isolation.READ_COMMITTED") {
             it("READ_COMMITTED isolation으로 트랜잭션이 정상 동작한다") {
-                val entity = propagationService.isolationReadCommitted("test")
+                val (entity, isolation) = propagationService.isolationReadCommitted("test")
 
                 entity.id.shouldNotBeNull()
+                isolation shouldBe "read committed"
                 propagationService.findByName("isolation-rc-test").shouldNotBeNull()
             }
         }
 
         describe("Isolation.REPEATABLE_READ") {
             it("REPEATABLE_READ isolation으로 트랜잭션이 정상 동작한다") {
-                val entity = propagationService.isolationRepeatableRead("test")
+                val (entity, isolation) = propagationService.isolationRepeatableRead("test")
 
                 entity.id.shouldNotBeNull()
+                isolation shouldBe "repeatable read"
                 propagationService.findByName("isolation-rr-test").shouldNotBeNull()
             }
         }
 
         describe("Isolation.SERIALIZABLE") {
             it("SERIALIZABLE isolation으로 트랜잭션이 정상 동작한다") {
-                val entity = propagationService.isolationSerializable("test")
+                val (entity, isolation) = propagationService.isolationSerializable("test")
 
                 entity.id.shouldNotBeNull()
+                isolation shouldBe "serializable"
                 propagationService.findByName("isolation-s-test").shouldNotBeNull()
             }
         }

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
@@ -1,5 +1,6 @@
 package io.clroot.hibernate.reactive.test.service
 
+import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
 import io.clroot.hibernate.reactive.test.entity.TestEntity
 import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
 import org.springframework.stereotype.Service
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class PropagationTestService(
     private val testEntityRepository: TestEntityRepository,
+    private val sessionProvider: TransactionalAwareSessionProvider,
 ) {
 
     // ============================================
@@ -136,19 +138,29 @@ class PropagationTestService(
     // ============================================
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    suspend fun isolationReadCommitted(name: String): TestEntity {
-        return testEntityRepository.save(TestEntity(name = "isolation-rc-$name", value = 80))
+    suspend fun isolationReadCommitted(name: String): Pair<TestEntity, String> {
+        val entity = testEntityRepository.save(TestEntity(name = "isolation-rc-$name", value = 80))
+        return entity to currentIsolationLevel()
     }
 
     @Transactional(isolation = Isolation.REPEATABLE_READ)
-    suspend fun isolationRepeatableRead(name: String): TestEntity {
-        return testEntityRepository.save(TestEntity(name = "isolation-rr-$name", value = 81))
+    suspend fun isolationRepeatableRead(name: String): Pair<TestEntity, String> {
+        val entity = testEntityRepository.save(TestEntity(name = "isolation-rr-$name", value = 81))
+        return entity to currentIsolationLevel()
     }
 
     @Transactional(isolation = Isolation.SERIALIZABLE)
-    suspend fun isolationSerializable(name: String): TestEntity {
-        return testEntityRepository.save(TestEntity(name = "isolation-s-$name", value = 82))
+    suspend fun isolationSerializable(name: String): Pair<TestEntity, String> {
+        val entity = testEntityRepository.save(TestEntity(name = "isolation-s-$name", value = 82))
+        return entity to currentIsolationLevel()
     }
+
+    private suspend fun currentIsolationLevel(): String =
+        sessionProvider.read { session ->
+            session
+                .createNativeQuery("show transaction_isolation", String::class.java)
+                .singleResult
+        }
 
     // ============================================
     // 헬퍼 메서드

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
@@ -68,7 +68,7 @@ public class HibernateReactiveTransactionManager(
 
                 runOnVertxContext(vertxContext) {
                     val reactiveConnection = getReactiveConnection(session)
-                    Uni.createFrom().completionStage(reactiveConnection.beginTransaction())
+                    TransactionIsolationConfigurer.begin(reactiveConnection, definition.isolationLevel)
                         .convert().with(UniReactorConverters.toMono())
                         .doOnSuccess {
                             session.isDefaultReadOnly = definition.isReadOnly
@@ -108,7 +108,7 @@ public class HibernateReactiveTransactionManager(
             }
             .chain { session ->
                 val reactiveConnection = getReactiveConnection(session)
-                Uni.createFrom().completionStage(reactiveConnection.beginTransaction())
+                TransactionIsolationConfigurer.begin(reactiveConnection, definition.isolationLevel)
                     .replaceWith(session)
             }
             .invoke { session ->

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionIsolationConfigurer.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionIsolationConfigurer.kt
@@ -1,0 +1,154 @@
+package io.clroot.hibernate.reactive.spring.boot.transaction
+
+import io.smallrye.mutiny.Uni
+import org.hibernate.reactive.pool.ReactiveConnection
+import org.springframework.transaction.InvalidIsolationLevelException
+import org.springframework.transaction.TransactionDefinition
+import java.util.Locale
+import java.util.concurrent.CompletionStage
+
+/**
+ * Applies Spring transaction isolation to a Hibernate Reactive connection.
+ *
+ * PostgreSQL changes the active transaction, while MySQL and MariaDB configure the
+ * next transaction. Keeping that ordering here prevents the transaction manager
+ * from silently falling back to the database default.
+ */
+internal object TransactionIsolationConfigurer {
+
+    fun begin(
+        connection: ReactiveConnection,
+        isolationLevel: Int,
+    ): Uni<Void> =
+        try {
+            beginConfigured(connection, isolationLevel)
+        } catch (error: Throwable) {
+            Uni.createFrom().failure(error)
+        }
+
+    private fun beginConfigured(
+        connection: ReactiveConnection,
+        isolationLevel: Int,
+    ): Uni<Void> {
+        val isolationClause = isolationClause(isolationLevel) ?: return beginTransaction(connection)
+        val productName = connection.databaseMetadata.productName()
+
+        return when (databaseFamily(productName)) {
+            DatabaseFamily.POSTGRESQL ->
+                beginTransaction(connection)
+                    .chain { _: Void? ->
+                        connection.executeUnprepared("SET TRANSACTION ISOLATION LEVEL $isolationClause")
+                            .asUni()
+                            .onFailure()
+                            .call { _: Throwable -> connection.rollbackTransaction().asUni() }
+                    }
+
+            DatabaseFamily.MYSQL ->
+                readMySqlSessionIsolation(connection)
+                    .chain { sessionIsolation ->
+                        connection.executeUnprepared("SET TRANSACTION ISOLATION LEVEL $isolationClause")
+                            .asUni()
+                            .chain { _: Void? ->
+                                beginTransaction(connection)
+                                    .onFailure()
+                                    .call { _: Throwable ->
+                                        restoreMySqlSessionIsolation(connection, sessionIsolation)
+                                    }
+                            }
+                    }
+
+            null ->
+                Uni.createFrom().failure(
+                    InvalidIsolationLevelException(
+                        "Transaction isolation level $isolationClause is not supported for database '$productName'",
+                    ),
+                )
+        }
+    }
+
+    private fun beginTransaction(connection: ReactiveConnection): Uni<Void> =
+        try {
+            connection.beginTransaction().asUni()
+        } catch (error: Throwable) {
+            Uni.createFrom().failure(error)
+        }
+
+    private fun readMySqlSessionIsolation(connection: ReactiveConnection): Uni<String> =
+        selectMySqlSessionIsolation(connection, "transaction_isolation")
+            .onFailure()
+            .recoverWithUni { _: Throwable -> selectMySqlSessionIsolation(connection, "tx_isolation") }
+
+    private fun selectMySqlSessionIsolation(
+        connection: ReactiveConnection,
+        variableName: String,
+    ): Uni<String> =
+        connection.select("SELECT @@SESSION.$variableName")
+            .asUni()
+            .map { result ->
+                if (!result.hasNext()) {
+                    throw InvalidIsolationLevelException(
+                        "Database did not return its current session isolation level",
+                    )
+                }
+
+                normalizeMySqlIsolation(result.next().firstOrNull())
+            }
+
+    private fun normalizeMySqlIsolation(value: Any?): String {
+        val normalizedValue = value
+            ?.toString()
+            ?.trim()
+            ?.uppercase(Locale.ROOT)
+            ?.replace('-', ' ')
+            ?.replace('_', ' ')
+
+        return when (normalizedValue) {
+            "READ UNCOMMITTED",
+            "READ COMMITTED",
+            "REPEATABLE READ",
+            "SERIALIZABLE",
+            -> normalizedValue
+
+            else ->
+                throw InvalidIsolationLevelException(
+                    "Database returned unsupported session isolation level '$value'",
+                )
+        }
+    }
+
+    private fun restoreMySqlSessionIsolation(
+        connection: ReactiveConnection,
+        isolationClause: String,
+    ): Uni<Void> =
+        connection.executeUnprepared("SET SESSION TRANSACTION ISOLATION LEVEL $isolationClause")
+            .asUni()
+
+    private fun isolationClause(isolationLevel: Int): String? =
+        when (isolationLevel) {
+            TransactionDefinition.ISOLATION_DEFAULT -> null
+            TransactionDefinition.ISOLATION_READ_UNCOMMITTED -> "READ UNCOMMITTED"
+            TransactionDefinition.ISOLATION_READ_COMMITTED -> "READ COMMITTED"
+            TransactionDefinition.ISOLATION_REPEATABLE_READ -> "REPEATABLE READ"
+            TransactionDefinition.ISOLATION_SERIALIZABLE -> "SERIALIZABLE"
+            else ->
+                throw InvalidIsolationLevelException(
+                    "Unsupported transaction isolation level value: $isolationLevel",
+                )
+        }
+
+    private fun databaseFamily(productName: String): DatabaseFamily? {
+        val normalizedName = productName.lowercase(Locale.ROOT)
+        return when {
+            "postgresql" in normalizedName -> DatabaseFamily.POSTGRESQL
+            "mysql" in normalizedName || "mariadb" in normalizedName -> DatabaseFamily.MYSQL
+            else -> null
+        }
+    }
+
+    private fun <T> CompletionStage<T>.asUni(): Uni<T> = Uni.createFrom().completionStage(this)
+
+    private enum class DatabaseFamily {
+        POSTGRESQL,
+        MYSQL,
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionIsolationConfigurerTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionIsolationConfigurerTest.kt
@@ -1,0 +1,187 @@
+package io.clroot.hibernate.reactive.spring.boot.transaction
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.vertx.sqlclient.spi.DatabaseMetadata
+import org.hibernate.reactive.pool.ReactiveConnection
+import org.springframework.transaction.InvalidIsolationLevelException
+import org.springframework.transaction.TransactionDefinition
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+class TransactionIsolationConfigurerTest : DescribeSpec({
+
+    fun completedVoid(): CompletionStage<Void> = CompletableFuture.completedFuture(null)
+
+    fun connection(productName: String, events: MutableList<String>): ReactiveConnection {
+        val metadata = mockk<DatabaseMetadata>()
+        val connection = mockk<ReactiveConnection>()
+        val isolationResult = mockk<ReactiveConnection.Result>()
+
+        every { metadata.productName() } returns productName
+        every { connection.databaseMetadata } returns metadata
+        every { isolationResult.hasNext() } returns true
+        every { isolationResult.next() } returns arrayOf("READ-COMMITTED")
+        every { connection.select(any()) } answers {
+            events += firstArg<String>()
+            CompletableFuture.completedFuture(isolationResult)
+        }
+        every { connection.beginTransaction() } answers {
+            events += "begin"
+            completedVoid()
+        }
+        every { connection.executeUnprepared(any()) } answers {
+            events += firstArg<String>()
+            completedVoid()
+        }
+        every { connection.rollbackTransaction() } answers {
+            events += "rollback"
+            completedVoid()
+        }
+
+        return connection
+    }
+
+    describe("transaction isolation configuration") {
+        it("begins directly when the database default is requested") {
+            val events = mutableListOf<String>()
+            val connection = connection("unknown", events)
+
+            TransactionIsolationConfigurer.begin(
+                connection,
+                TransactionDefinition.ISOLATION_DEFAULT,
+            ).await().indefinitely()
+
+            events shouldContainExactly listOf("begin")
+        }
+
+        it("configures PostgreSQL after beginning the transaction") {
+            val events = mutableListOf<String>()
+            val connection = connection("PostgreSQL", events)
+
+            TransactionIsolationConfigurer.begin(
+                connection,
+                TransactionDefinition.ISOLATION_REPEATABLE_READ,
+            ).await().indefinitely()
+
+            events shouldContainExactly
+                listOf("begin", "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        }
+
+        it("configures MySQL and MariaDB before beginning the transaction") {
+            listOf("MySQL", "MariaDB").forEach { productName ->
+                val events = mutableListOf<String>()
+                val connection = connection(productName, events)
+
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_SERIALIZABLE,
+                ).await().indefinitely()
+
+                events shouldContainExactly
+                    listOf(
+                        "SELECT @@SESSION.transaction_isolation",
+                        "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+                        "begin",
+                    )
+            }
+        }
+
+        it("restores the MySQL session isolation when begin fails") {
+            val events = mutableListOf<String>()
+            val connection = connection("MySQL", events)
+            every { connection.beginTransaction() } answers {
+                events += "begin"
+                CompletableFuture.failedFuture(IllegalStateException("begin failed"))
+            }
+
+            shouldThrow<IllegalStateException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_SERIALIZABLE,
+                ).await().indefinitely()
+            }.message shouldBe "begin failed"
+
+            events shouldContainExactly
+                listOf(
+                    "SELECT @@SESSION.transaction_isolation",
+                    "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+                    "begin",
+                    "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+                )
+        }
+
+        it("restores the MySQL session isolation when begin throws synchronously") {
+            val events = mutableListOf<String>()
+            val connection = connection("MySQL", events)
+            every { connection.beginTransaction() } answers {
+                events += "begin"
+                throw IllegalStateException("transaction already active")
+            }
+
+            shouldThrow<IllegalStateException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_REPEATABLE_READ,
+                ).await().indefinitely()
+            }.message shouldBe "transaction already active"
+
+            events shouldContainExactly
+                listOf(
+                    "SELECT @@SESSION.transaction_isolation",
+                    "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+                    "begin",
+                    "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+                )
+        }
+
+        it("rolls back PostgreSQL when applying isolation fails after begin") {
+            val events = mutableListOf<String>()
+            val connection = connection("PostgreSQL", events)
+            every { connection.executeUnprepared(any()) } answers {
+                events += firstArg<String>()
+                CompletableFuture.failedFuture(IllegalStateException("isolation failed"))
+            }
+
+            shouldThrow<IllegalStateException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_SERIALIZABLE,
+                ).await().indefinitely()
+            }.message shouldBe "isolation failed"
+
+            events shouldContainExactly
+                listOf("begin", "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE", "rollback")
+        }
+
+        it("rejects explicit isolation for unsupported databases") {
+            val events = mutableListOf<String>()
+            val connection = connection("Oracle", events)
+
+            shouldThrow<InvalidIsolationLevelException> {
+                TransactionIsolationConfigurer.begin(
+                    connection,
+                    TransactionDefinition.ISOLATION_READ_COMMITTED,
+                ).await().indefinitely()
+            }
+
+            events shouldContainExactly emptyList()
+        }
+
+        it("rejects unknown Spring isolation constants") {
+            val events = mutableListOf<String>()
+            val connection = connection("PostgreSQL", events)
+            val result = TransactionIsolationConfigurer.begin(connection, Int.MAX_VALUE)
+
+            shouldThrow<InvalidIsolationLevelException> {
+                result.await().indefinitely()
+            }
+
+            events shouldContainExactly emptyList()
+        }
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionIsolationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionIsolationTest.kt
@@ -1,6 +1,7 @@
 package io.clroot.hibernate.reactive.test
 
 import io.clroot.hibernate.reactive.test.service.PropagationTestService
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.nulls.shouldNotBeNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -16,9 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest
  * - 기본값은 Isolation.DEFAULT (데이터베이스 기본값 사용)
  * - 지원 레벨: READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE
  *
- * ## 현재 구현
- * - Hibernate Reactive는 데이터베이스의 기본 isolation을 사용
- * - isolation 설정이 예외 없이 적용되고 트랜잭션이 정상 동작하는지 검증
+ * 각 트랜잭션 안에서 PostgreSQL의 실제 isolation 값을 조회하여 선언한 수준이 적용됐는지 검증합니다.
  */
 @SpringBootTest(classes = [TestApplication::class, PropagationTestService::class])
 class TransactionIsolationTest : IntegrationTestBase() {
@@ -29,27 +28,30 @@ class TransactionIsolationTest : IntegrationTestBase() {
     init {
         describe("Isolation.READ_COMMITTED") {
             it("READ_COMMITTED isolation으로 트랜잭션이 정상 동작한다") {
-                val entity = propagationService.isolationReadCommitted("test")
+                val (entity, isolation) = propagationService.isolationReadCommitted("test")
 
                 entity.id.shouldNotBeNull()
+                isolation shouldBe "read committed"
                 propagationService.findByName("isolation-rc-test").shouldNotBeNull()
             }
         }
 
         describe("Isolation.REPEATABLE_READ") {
             it("REPEATABLE_READ isolation으로 트랜잭션이 정상 동작한다") {
-                val entity = propagationService.isolationRepeatableRead("test")
+                val (entity, isolation) = propagationService.isolationRepeatableRead("test")
 
                 entity.id.shouldNotBeNull()
+                isolation shouldBe "repeatable read"
                 propagationService.findByName("isolation-rr-test").shouldNotBeNull()
             }
         }
 
         describe("Isolation.SERIALIZABLE") {
             it("SERIALIZABLE isolation으로 트랜잭션이 정상 동작한다") {
-                val entity = propagationService.isolationSerializable("test")
+                val (entity, isolation) = propagationService.isolationSerializable("test")
 
                 entity.id.shouldNotBeNull()
+                isolation shouldBe "serializable"
                 propagationService.findByName("isolation-s-test").shouldNotBeNull()
             }
         }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
@@ -1,5 +1,6 @@
 package io.clroot.hibernate.reactive.test.service
 
+import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
 import io.clroot.hibernate.reactive.test.entity.TestEntity
 import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
 import org.springframework.stereotype.Service
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class PropagationTestService(
     private val testEntityRepository: TestEntityRepository,
+    private val sessionProvider: TransactionalAwareSessionProvider,
 ) {
 
     // ============================================
@@ -136,19 +138,29 @@ class PropagationTestService(
     // ============================================
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    suspend fun isolationReadCommitted(name: String): TestEntity {
-        return testEntityRepository.save(TestEntity(name = "isolation-rc-$name", value = 80))
+    suspend fun isolationReadCommitted(name: String): Pair<TestEntity, String> {
+        val entity = testEntityRepository.save(TestEntity(name = "isolation-rc-$name", value = 80))
+        return entity to currentIsolationLevel()
     }
 
     @Transactional(isolation = Isolation.REPEATABLE_READ)
-    suspend fun isolationRepeatableRead(name: String): TestEntity {
-        return testEntityRepository.save(TestEntity(name = "isolation-rr-$name", value = 81))
+    suspend fun isolationRepeatableRead(name: String): Pair<TestEntity, String> {
+        val entity = testEntityRepository.save(TestEntity(name = "isolation-rr-$name", value = 81))
+        return entity to currentIsolationLevel()
     }
 
     @Transactional(isolation = Isolation.SERIALIZABLE)
-    suspend fun isolationSerializable(name: String): TestEntity {
-        return testEntityRepository.save(TestEntity(name = "isolation-s-$name", value = 82))
+    suspend fun isolationSerializable(name: String): Pair<TestEntity, String> {
+        val entity = testEntityRepository.save(TestEntity(name = "isolation-s-$name", value = 82))
+        return entity to currentIsolationLevel()
     }
+
+    private suspend fun currentIsolationLevel(): String =
+        sessionProvider.read { session ->
+            session
+                .createNativeQuery("show transaction_isolation", String::class.java)
+                .singleResult
+        }
 
     // ============================================
     // 헬퍼 메서드


### PR DESCRIPTION
## Summary
- apply explicit Spring transaction isolation levels instead of silently using the database default
- honor PostgreSQL and MySQL/MariaDB transaction-control ordering and restore MySQL session state on begin failures
- fail reactively for unsupported isolation values/databases
- verify actual PostgreSQL session isolation in both Boot 3 and Boot 4 starters

## Verification
- `JAVA_HOME=...temurin-17.0.17... ./gradlew clean build --no-build-cache`
- final `./gradlew build --no-build-cache`
- independent Spec and Standards reviews of commit `399f4f9` (no findings)