### PR TITLE
fix: enforce Spring transaction timeouts

### DIFF
--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManagerTimeoutTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManagerTimeoutTest.kt
@@ -1,0 +1,65 @@
+package io.clroot.hibernate.reactive.spring.boot.transaction
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import io.smallrye.mutiny.Uni
+import org.hibernate.reactive.mutiny.Mutiny
+import org.hibernate.reactive.pool.ReactiveConnection
+import org.springframework.transaction.TransactionTimedOutException
+import org.springframework.transaction.UnexpectedRollbackException
+import java.util.concurrent.CompletableFuture
+
+class HibernateReactiveTransactionManagerTimeoutTest : DescribeSpec({
+
+    describe("transaction commit deadline") {
+        it("flushes and commits while the deadline is active") {
+            val sessionFactory = mockk<Mutiny.SessionFactory>()
+            val session = mockk<Mutiny.Session>()
+            val connection = mockk<ReactiveConnection>()
+            val holder = MutinySessionHolder(session)
+            val manager = HibernateReactiveTransactionManager(sessionFactory)
+
+            every { session.flush() } returns Uni.createFrom().voidItem()
+            every { connection.commitTransaction() } returns CompletableFuture.completedFuture(null)
+
+            manager.completeTransaction(holder, session, connection)
+                .await().indefinitely()
+
+            verifyOrder {
+                session.flush()
+                connection.commitTransaction()
+            }
+            verify(exactly = 0) { connection.rollbackTransaction() }
+        }
+
+        it("rolls back when the deadline expires during flush") {
+            val sessionFactory = mockk<Mutiny.SessionFactory>()
+            val session = mockk<Mutiny.Session>()
+            val connection = mockk<ReactiveConnection>()
+            val holder = MutinySessionHolder(session)
+            val manager = HibernateReactiveTransactionManager(sessionFactory)
+
+            every { session.flush() } returns
+                    Uni.createFrom().voidItem()
+                        .invoke { _: Void? -> holder.markTransactionTimedOut() }
+            every { connection.rollbackTransaction() } returns CompletableFuture.completedFuture(null)
+
+            val error = shouldThrow<UnexpectedRollbackException> {
+                manager.completeTransaction(holder, session, connection)
+                    .await().indefinitely()
+            }
+            error.mostSpecificCause.shouldBeInstanceOf<TransactionTimedOutException>()
+
+            verifyOrder {
+                session.flush()
+                connection.rollbackTransaction()
+            }
+            verify(exactly = 0) { connection.commitTransaction() }
+        }
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionTimeoutTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionTimeoutTest.kt
@@ -1,9 +1,14 @@
 package io.clroot.hibernate.reactive.test
 
 import io.clroot.hibernate.reactive.test.service.PropagationTestService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.TransactionTimedOutException
+import org.springframework.transaction.UnexpectedRollbackException
 
 /**
  * Spring @Transactional timeout 속성 테스트.
@@ -16,9 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest
  * - 기본값은 -1 (타임아웃 없음, 기반 트랜잭션 시스템의 기본값 사용)
  * - 타임아웃 초과 시 TransactionTimedOutException 발생
  *
- * ## 현재 구현
- * - MutinySessionHolder에 timeout이 설정됨
- * - Hibernate Reactive의 커넥션 레벨에서 처리됨
+ * 제한 시간을 넘긴 트랜잭션은 커밋되지 않고 Spring의 표준 timeout 예외를 발생시켜야 합니다.
  */
 @SpringBootTest(classes = [TestApplication::class, PropagationTestService::class])
 class TransactionTimeoutTest : IntegrationTestBase() {
@@ -37,9 +40,33 @@ class TransactionTimeoutTest : IntegrationTestBase() {
                 }
             }
 
-            // Note: 짧은 timeout + 긴 지연 테스트는 Hibernate Reactive의 timeout 구현에 따라
-            // 다르게 동작할 수 있습니다. 실제 timeout 강제는 DB 커넥션/드라이버 레벨에서 처리되므로
-            // 코루틴 delay()로는 정확한 timeout 테스트가 어렵습니다.
+            context("timeout 초과") {
+                it("timeout=1을 넘긴 트랜잭션은 롤백된다") {
+                    val error = shouldThrow<UnexpectedRollbackException> {
+                        propagationService.transactionWithShortTimeout("timeout-expired", 1_500)
+                    }
+                    error.mostSpecificCause.shouldBeInstanceOf<TransactionTimedOutException>()
+
+                    propagationService.findByName("timeout-expired").shouldBeNull()
+                }
+
+                it("deadline 이후의 리포지토리 호출은 실행 전에 거부된다") {
+                    shouldThrow<TransactionTimedOutException> {
+                        propagationService.repositoryCallAfterTimeout("timeout-before-query", 1_100)
+                    }
+
+                    propagationService.findByName("timeout-before-query").shouldBeNull()
+                }
+
+                it("호출자가 timeout 예외를 잡아도 트랜잭션은 커밋되지 않는다") {
+                    val error = shouldThrow<UnexpectedRollbackException> {
+                        propagationService.catchRepositoryTimeout("timeout-caught", 1_100)
+                    }
+                    error.mostSpecificCause.shouldBeInstanceOf<TransactionTimedOutException>()
+
+                    propagationService.findByName("timeout-caught").shouldBeNull()
+                }
+            }
         }
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
@@ -133,6 +133,22 @@ class PropagationTestService(
         return testEntityRepository.save(TestEntity(name = name, value = 71))
     }
 
+    @Transactional(timeout = 1)
+    suspend fun repositoryCallAfterTimeout(name: String, delayMillis: Long): TestEntity {
+        kotlinx.coroutines.delay(delayMillis)
+        return testEntityRepository.save(TestEntity(name = name, value = 72))
+    }
+
+    @Transactional(timeout = 1)
+    suspend fun catchRepositoryTimeout(name: String, delayMillis: Long) {
+        kotlinx.coroutines.delay(delayMillis)
+        try {
+            testEntityRepository.save(TestEntity(name = name, value = 73))
+        } catch (_: org.springframework.transaction.TransactionTimedOutException) {
+            // The transaction must remain rollback-only even if application code catches the operation error.
+        }
+    }
+
     // ============================================
     // isolation 테스트
     // ============================================

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
@@ -12,14 +12,13 @@ import org.hibernate.reactive.session.ReactiveConnectionSupplier
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.TransactionTimedOutException
 import org.springframework.transaction.UnexpectedRollbackException
 import org.springframework.transaction.reactive.AbstractReactiveTransactionManager
 import org.springframework.transaction.reactive.GenericReactiveTransaction
 import org.springframework.transaction.reactive.TransactionSynchronizationManager
 import reactor.core.publisher.Mono
-import java.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toKotlinDuration
 
 /**
  * Hibernate Reactive (Mutiny API)를 위한 Spring ReactiveTransactionManager 구현체.
@@ -63,8 +62,10 @@ public class HibernateReactiveTransactionManager(
                 openSessionAndBeginTransaction(txObject, definition, synchronizationManager)
             } else {
                 txObject.getSessionHolder().isSynchronizedWithTransaction = true
-                val session = txObject.getSessionHolder().getSession()
-                val vertxContext = txObject.getSessionHolder().getVertxContext()
+                val sessionHolder = txObject.getSessionHolder()
+                val session = sessionHolder.getSession()
+                val vertxContext = sessionHolder.getVertxContext()
+                sessionHolder.configureTransaction(transactionMode(definition), transactionTimeout(definition))
 
                 runOnVertxContext(vertxContext) {
                     val reactiveConnection = getReactiveConnection(session)
@@ -72,8 +73,7 @@ public class HibernateReactiveTransactionManager(
                         .convert().with(UniReactorConverters.toMono())
                         .doOnSuccess {
                             session.isDefaultReadOnly = definition.isReadOnly
-                            txObject.getSessionHolder().setTransactionActive(true)
-                            applyTimeout(txObject, definition)
+                            sessionHolder.setTransactionActive(true)
                         }
                 }
             }
@@ -96,14 +96,12 @@ public class HibernateReactiveTransactionManager(
 
                 // 세션이 생성된 후, 현재 스레드는 Hibernate Reactive의 Vert.x EventLoop 스레드
                 val vertxContext = Vertx.currentContext()
-                val timeout = if (definition.timeout != TransactionDefinition.TIMEOUT_DEFAULT) {
-                    definition.timeout.seconds
-                } else {
-                    kotlin.time.Duration.INFINITE
-                }
-                val mode = if (definition.isReadOnly) TransactionMode.READ_ONLY else TransactionMode.READ_WRITE
-
-                val holder = MutinySessionHolder(session, vertxContext, mode, timeout)
+                val holder = MutinySessionHolder(
+                    session,
+                    vertxContext,
+                    transactionMode(definition),
+                    transactionTimeout(definition),
+                )
                 txObject.setSessionHolder(holder, true)
             }
             .chain { session ->
@@ -130,13 +128,6 @@ public class HibernateReactiveTransactionManager(
             .then()
     }
 
-    private fun applyTimeout(txObject: HibernateTransactionObject, definition: TransactionDefinition) {
-        if (definition.timeout != TransactionDefinition.TIMEOUT_DEFAULT) {
-            val timeout = Duration.ofSeconds(definition.timeout.toLong())
-            txObject.getSessionHolder().setTimeoutInMillis(timeout.toMillis())
-        }
-    }
-
     override fun doCommit(
         synchronizationManager: TransactionSynchronizationManager,
         status: GenericReactiveTransaction,
@@ -149,7 +140,7 @@ public class HibernateReactiveTransactionManager(
 
         // 참여 트랜잭션에서 rollback-only가 설정되었으면 UnexpectedRollbackException 발생
         // Spring 표준 동작: 내부 트랜잭션이 rollback-only로 마킹되면 외부 커밋 시 예외 발생
-        if (sessionHolder.isRollbackOnly) {
+        if (sessionHolder.isRollbackOnly && !hasTransactionTimedOut(sessionHolder)) {
             return runOnVertxContext(sessionHolder.getVertxContext()) {
                 val reactiveConnection = getReactiveConnection(session)
                 Uni.createFrom().completionStage(reactiveConnection.rollbackTransaction())
@@ -164,14 +155,50 @@ public class HibernateReactiveTransactionManager(
         }
 
         return runOnVertxContext(sessionHolder.getVertxContext()) {
-            // 커밋 전에 영속성 컨텍스트의 변경사항을 DB에 반영
-            session.flush()
-                .chain { _ ->
-                    val reactiveConnection = getReactiveConnection(session)
-                    Uni.createFrom().completionStage(reactiveConnection.commitTransaction())
-                }
+            val reactiveConnection = getReactiveConnection(session)
+            completeTransaction(sessionHolder, session, reactiveConnection)
                 .convert().with(UniReactorConverters.toMono())
         }
+    }
+
+    internal fun completeTransaction(
+        sessionHolder: MutinySessionHolder,
+        session: Mutiny.Session,
+        reactiveConnection: ReactiveConnection,
+    ): Uni<Void> {
+        if (hasTransactionTimedOut(sessionHolder)) {
+            return rollbackTimedOutTransaction(sessionHolder, reactiveConnection)
+        }
+
+        // 커밋 전에 영속성 컨텍스트의 변경사항을 DB에 반영
+        return session.flush()
+            .chain { _: Void? ->
+                if (hasTransactionTimedOut(sessionHolder)) {
+                    rollbackTimedOutTransaction(sessionHolder, reactiveConnection)
+                } else {
+                    Uni.createFrom().completionStage(reactiveConnection.commitTransaction())
+                }
+            }
+    }
+
+    private fun hasTransactionTimedOut(sessionHolder: MutinySessionHolder): Boolean =
+        sessionHolder.isTransactionTimedOut() ||
+                sessionHolder.toReactiveSessionContext().remainingTimeout() == kotlin.time.Duration.ZERO
+
+    private fun rollbackTimedOutTransaction(
+        sessionHolder: MutinySessionHolder,
+        reactiveConnection: ReactiveConnection,
+    ): Uni<Void> {
+        sessionHolder.markTransactionTimedOut()
+        val timeout = TransactionTimedOutException(
+            "Hibernate Reactive transaction exceeded its configured timeout",
+        )
+        val error = UnexpectedRollbackException(
+            "Hibernate Reactive transaction rolled back because its timeout expired",
+            timeout,
+        )
+        return Uni.createFrom().completionStage(reactiveConnection.rollbackTransaction())
+            .chain { _: Void? -> Uni.createFrom().failure(error) }
     }
 
     override fun doRollback(
@@ -317,6 +344,16 @@ public class HibernateReactiveTransactionManager(
             )
         }
     }
+
+    private fun transactionMode(definition: TransactionDefinition): TransactionMode =
+        if (definition.isReadOnly) TransactionMode.READ_ONLY else TransactionMode.READ_WRITE
+
+    private fun transactionTimeout(definition: TransactionDefinition): kotlin.time.Duration =
+        if (definition.timeout == TransactionDefinition.TIMEOUT_DEFAULT) {
+            kotlin.time.Duration.INFINITE
+        } else {
+            definition.timeout.seconds
+        }
 
     /**
      * 트랜잭션 객체 - 내부 상태 관리

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/MutinySessionHolder.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/MutinySessionHolder.kt
@@ -16,12 +16,13 @@ import kotlin.time.Duration
 public class MutinySessionHolder(
     private var session: Mutiny.Session?,
     private var vertxContext: Context? = null,
-    private val mode: TransactionMode = TransactionMode.READ_WRITE,
-    private val timeout: Duration = Duration.INFINITE,
-    private val startTimeNanos: Long = System.nanoTime(),
+    private var mode: TransactionMode = TransactionMode.READ_WRITE,
+    private var timeout: Duration = Duration.INFINITE,
+    private var startTimeNanos: Long = System.nanoTime(),
 ) : ResourceHolderSupport() {
 
     private var transactionActive: Boolean = false
+    private var transactionTimedOut: Boolean = false
 
     public fun getSession(): Mutiny.Session {
         return session ?: throw IllegalStateException("No Mutiny.Session available")
@@ -53,6 +54,20 @@ public class MutinySessionHolder(
 
     public fun isTransactionActive(): Boolean = transactionActive
 
+    internal fun configureTransaction(mode: TransactionMode, timeout: Duration) {
+        this.mode = mode
+        this.timeout = timeout
+        this.startTimeNanos = System.nanoTime()
+        this.transactionTimedOut = false
+    }
+
+    internal fun markTransactionTimedOut() {
+        transactionTimedOut = true
+        setRollbackOnly()
+    }
+
+    internal fun isTransactionTimedOut(): Boolean = transactionTimedOut
+
     /**
      * 현재 세션 홀더에서 ReactiveSessionContext를 생성합니다.
      * 코루틴 컨텍스트에 세션을 전파할 때 사용합니다.
@@ -69,6 +84,7 @@ public class MutinySessionHolder(
     override fun clear() {
         super.clear()
         transactionActive = false
+        transactionTimedOut = false
     }
 
     override fun released() {

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider.kt
@@ -1,6 +1,7 @@
 package io.clroot.hibernate.reactive.spring.boot.transaction
 
 import io.clroot.hibernate.reactive.ReadOnlyTransactionException
+import io.clroot.hibernate.reactive.ReactiveSessionContext
 import io.clroot.hibernate.reactive.currentContextOrNull
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
@@ -10,8 +11,10 @@ import kotlinx.coroutines.reactor.ReactorContext
 import kotlinx.coroutines.withContext
 import org.hibernate.reactive.mutiny.Mutiny
 import org.springframework.transaction.NoTransactionException
+import org.springframework.transaction.TransactionTimedOutException
 import org.springframework.transaction.reactive.TransactionSynchronizationManager
 import kotlin.reflect.KProperty1
+import kotlin.time.Duration
 
 /**
  * @Transactional 컨텍스트를 인식하는 세션 제공자.
@@ -49,9 +52,7 @@ public open class TransactionalAwareSessionProvider(
         // 1. @Transactional 컨텍스트 확인
         val transactionalContext = getTransactionalSessionContext()
         if (transactionalContext != null) {
-            return withContext(transactionalContext.dispatcher ?: currentCoroutineContext()) {
-                block(transactionalContext.session).awaitSuspending()
-            }
+            return executeWithTransactionTimeout(transactionalContext, block)
         }
 
         // 2. ReactiveSessionContext 확인 (기존 tx.transactional 방식)
@@ -86,9 +87,7 @@ public open class TransactionalAwareSessionProvider(
                             "Remove readOnly=true from @Transactional annotation.",
                 )
             }
-            return withContext(transactionalContext.dispatcher ?: currentCoroutineContext()) {
-                block(transactionalContext.session).awaitSuspending()
-            }
+            return executeWithTransactionTimeout(transactionalContext, block)
         }
 
         // 2. ReactiveSessionContext 확인 (기존 tx.transactional 방식)
@@ -135,7 +134,8 @@ public open class TransactionalAwareSessionProvider(
                     }
                     TransactionalSessionInfo(
                         session = holder.getSession(),
-                        isReadOnly = holder.toReactiveSessionContext().isReadOnly,
+                        sessionContext = holder.toReactiveSessionContext(),
+                        holder = holder,
                         dispatcher = holder.getDispatcher(),
                     )
                 }
@@ -148,9 +148,35 @@ public open class TransactionalAwareSessionProvider(
 
     private data class TransactionalSessionInfo(
         val session: Mutiny.Session,
-        val isReadOnly: Boolean,
+        val sessionContext: ReactiveSessionContext,
+        val holder: MutinySessionHolder,
         val dispatcher: kotlinx.coroutines.CoroutineDispatcher?,
-    )
+    ) {
+        val isReadOnly: Boolean
+            get() = sessionContext.isReadOnly
+    }
+
+    private suspend fun <T> executeWithTransactionTimeout(
+        transaction: TransactionalSessionInfo,
+        block: (Mutiny.Session) -> Uni<T>,
+    ): T {
+        checkTransactionTimeout(transaction)
+        val result = withContext(transaction.dispatcher ?: currentCoroutineContext()) {
+            checkTransactionTimeout(transaction)
+            block(transaction.session).awaitSuspending()
+        }
+        checkTransactionTimeout(transaction)
+        return result
+    }
+
+    private fun checkTransactionTimeout(transaction: TransactionalSessionInfo) {
+        if (transaction.sessionContext.remainingTimeout() == Duration.ZERO) {
+            transaction.holder.markTransactionTimedOut()
+            throw TransactionTimedOutException(
+                "Hibernate Reactive transaction exceeded its configured timeout",
+            )
+        }
+    }
 
     // ==================== Lazy Loading 편의 메서드 ====================
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManagerTimeoutTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManagerTimeoutTest.kt
@@ -1,0 +1,65 @@
+package io.clroot.hibernate.reactive.spring.boot.transaction
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import io.smallrye.mutiny.Uni
+import org.hibernate.reactive.mutiny.Mutiny
+import org.hibernate.reactive.pool.ReactiveConnection
+import org.springframework.transaction.TransactionTimedOutException
+import org.springframework.transaction.UnexpectedRollbackException
+import java.util.concurrent.CompletableFuture
+
+class HibernateReactiveTransactionManagerTimeoutTest : DescribeSpec({
+
+    describe("transaction commit deadline") {
+        it("flushes and commits while the deadline is active") {
+            val sessionFactory = mockk<Mutiny.SessionFactory>()
+            val session = mockk<Mutiny.Session>()
+            val connection = mockk<ReactiveConnection>()
+            val holder = MutinySessionHolder(session)
+            val manager = HibernateReactiveTransactionManager(sessionFactory)
+
+            every { session.flush() } returns Uni.createFrom().voidItem()
+            every { connection.commitTransaction() } returns CompletableFuture.completedFuture(null)
+
+            manager.completeTransaction(holder, session, connection)
+                .await().indefinitely()
+
+            verifyOrder {
+                session.flush()
+                connection.commitTransaction()
+            }
+            verify(exactly = 0) { connection.rollbackTransaction() }
+        }
+
+        it("rolls back when the deadline expires during flush") {
+            val sessionFactory = mockk<Mutiny.SessionFactory>()
+            val session = mockk<Mutiny.Session>()
+            val connection = mockk<ReactiveConnection>()
+            val holder = MutinySessionHolder(session)
+            val manager = HibernateReactiveTransactionManager(sessionFactory)
+
+            every { session.flush() } returns
+                    Uni.createFrom().voidItem()
+                        .invoke { _: Void? -> holder.markTransactionTimedOut() }
+            every { connection.rollbackTransaction() } returns CompletableFuture.completedFuture(null)
+
+            val error = shouldThrow<UnexpectedRollbackException> {
+                manager.completeTransaction(holder, session, connection)
+                    .await().indefinitely()
+            }
+            error.mostSpecificCause.shouldBeInstanceOf<TransactionTimedOutException>()
+
+            verifyOrder {
+                session.flush()
+                connection.rollbackTransaction()
+            }
+            verify(exactly = 0) { connection.commitTransaction() }
+        }
+    }
+})

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionTimeoutTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionTimeoutTest.kt
@@ -1,9 +1,14 @@
 package io.clroot.hibernate.reactive.test
 
 import io.clroot.hibernate.reactive.test.service.PropagationTestService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.TransactionTimedOutException
+import org.springframework.transaction.UnexpectedRollbackException
 
 /**
  * Spring @Transactional timeout 속성 테스트.
@@ -16,9 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest
  * - 기본값은 -1 (타임아웃 없음, 기반 트랜잭션 시스템의 기본값 사용)
  * - 타임아웃 초과 시 TransactionTimedOutException 발생
  *
- * ## 현재 구현
- * - MutinySessionHolder에 timeout이 설정됨
- * - Hibernate Reactive의 커넥션 레벨에서 처리됨
+ * 제한 시간을 넘긴 트랜잭션은 커밋되지 않고 Spring의 표준 timeout 예외를 발생시켜야 합니다.
  */
 @SpringBootTest(classes = [TestApplication::class, PropagationTestService::class])
 class TransactionTimeoutTest : IntegrationTestBase() {
@@ -37,9 +40,33 @@ class TransactionTimeoutTest : IntegrationTestBase() {
                 }
             }
 
-            // Note: 짧은 timeout + 긴 지연 테스트는 Hibernate Reactive의 timeout 구현에 따라
-            // 다르게 동작할 수 있습니다. 실제 timeout 강제는 DB 커넥션/드라이버 레벨에서 처리되므로
-            // 코루틴 delay()로는 정확한 timeout 테스트가 어렵습니다.
+            context("timeout 초과") {
+                it("timeout=1을 넘긴 트랜잭션은 롤백된다") {
+                    val error = shouldThrow<UnexpectedRollbackException> {
+                        propagationService.transactionWithShortTimeout("timeout-expired", 1_500)
+                    }
+                    error.mostSpecificCause.shouldBeInstanceOf<TransactionTimedOutException>()
+
+                    propagationService.findByName("timeout-expired").shouldBeNull()
+                }
+
+                it("deadline 이후의 리포지토리 호출은 실행 전에 거부된다") {
+                    shouldThrow<TransactionTimedOutException> {
+                        propagationService.repositoryCallAfterTimeout("timeout-before-query", 1_100)
+                    }
+
+                    propagationService.findByName("timeout-before-query").shouldBeNull()
+                }
+
+                it("호출자가 timeout 예외를 잡아도 트랜잭션은 커밋되지 않는다") {
+                    val error = shouldThrow<UnexpectedRollbackException> {
+                        propagationService.catchRepositoryTimeout("timeout-caught", 1_100)
+                    }
+                    error.mostSpecificCause.shouldBeInstanceOf<TransactionTimedOutException>()
+
+                    propagationService.findByName("timeout-caught").shouldBeNull()
+                }
+            }
         }
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/PropagationTestService.kt
@@ -133,6 +133,22 @@ class PropagationTestService(
         return testEntityRepository.save(TestEntity(name = name, value = 71))
     }
 
+    @Transactional(timeout = 1)
+    suspend fun repositoryCallAfterTimeout(name: String, delayMillis: Long): TestEntity {
+        kotlinx.coroutines.delay(delayMillis)
+        return testEntityRepository.save(TestEntity(name = name, value = 72))
+    }
+
+    @Transactional(timeout = 1)
+    suspend fun catchRepositoryTimeout(name: String, delayMillis: Long) {
+        kotlinx.coroutines.delay(delayMillis)
+        try {
+            testEntityRepository.save(TestEntity(name = name, value = 73))
+        } catch (_: org.springframework.transaction.TransactionTimedOutException) {
+            // The transaction must remain rollback-only even if application code catches the operation error.
+        }
+    }
+
     // ============================================
     // isolation 테스트
     // ============================================


### PR DESCRIPTION
## Summary
- enforce Spring transaction deadlines before repository operations and again on the Vert.x dispatcher
- prevent commit when a deadline expires during flush, rolling back with Spring-compatible completion status
- preserve rollback-only state when application code catches an operation timeout
- add equivalent Boot 3 and Boot 4 unit/integration regression coverage

## Verification
- `JAVA_HOME=/Users/clroot/Library/Java/JavaVirtualMachines/temurin-17.0.17/Contents/Home ./gradlew clean build --no-build-cache`
- independent Spec review: no findings
- independent Standards review: no findings