### PR TITLE
fix: reuse active transaction for saveAll

### DIFF
--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
@@ -2,15 +2,22 @@ package io.clroot.hibernate.reactive.spring.boot.repository
 
 import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.isActive
+import jakarta.persistence.Id
+import org.hibernate.reactive.mutiny.Mutiny
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import java.lang.reflect.Proxy
 import kotlin.coroutines.EmptyCoroutineContext
@@ -182,11 +189,51 @@ class SimpleHibernateReactiveRepositoryTest : DescribeSpec({
                 capturedError!!.message shouldContain "save"
             }
         }
+
+        context("saveAll 트랜잭션 경계") {
+            it("모든 저장을 하나의 sessionProvider write 경계에서 실행한다") {
+                val localSessionProvider = mockk<TransactionalAwareSessionProvider>()
+                val localTransactionExecutor = mockk<ReactiveTransactionExecutor>()
+                val session = mockk<Mutiny.Session>()
+                var writeCalls = 0
+
+                coEvery {
+                    localSessionProvider.write<Any?>(any())
+                } coAnswers {
+                    writeCalls++
+                    firstArg<(Mutiny.Session) -> Uni<Any?>>()
+                        .invoke(session)
+                        .awaitSuspending()
+                }
+                coEvery {
+                    localTransactionExecutor.transactional<Any?>(any(), any())
+                } coAnswers {
+                    secondArg<suspend () -> Any?>().invoke()
+                }
+                every { session.persist(any()) } returns Uni.createFrom().voidItem()
+
+                val crud = CrudOperations<SaveAllEntity, Long>(
+                    entityClass = SaveAllEntity::class.java,
+                    sessionProvider = localSessionProvider,
+                    transactionExecutor = localTransactionExecutor,
+                    auditingHandler = null,
+                )
+
+                val saved = crud.saveAll(List(2_000) { SaveAllEntity() }).toList()
+
+                writeCalls shouldBe 1
+                saved.size shouldBe 2_000
+                coVerify(exactly = 0) {
+                    localTransactionExecutor.transactional<Any?>(any(), any())
+                }
+            }
+        }
     }
 }) {
     companion object {
         interface TestRepository : CoroutineCrudRepository<TestEntity, Long>
         class TestEntity
+        class SaveAllEntity(@Id val id: Long? = null)
 
         // 에러 메시지 테스트용 인터페이스 (오타가 포함된 메서드명)
         @Suppress("unused")

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -3,11 +3,14 @@ package io.clroot.hibernate.reactive.spring.boot.repository
 import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
 import io.clroot.hibernate.reactive.spring.boot.auditing.ReactiveAuditingHandler
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.Uni
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
+import org.hibernate.reactive.mutiny.Mutiny
 
 /**
  * 기본 CRUD 작업을 담당하는 내부 헬퍼 클래스.
@@ -25,11 +28,7 @@ internal class CrudOperations<T : Any, ID : Any>(
 ) {
     private val entityName: String = entityClass.simpleName
 
-    // ============================================
-    // Save 작업
-    // ============================================
-
-    suspend fun save(entity: T): T {
+    private suspend fun prepareEntity(entity: T): Boolean {
         val isNew = EntityStateDetector.isNew(entity)
         if (auditingHandler != null) {
             if (isNew) {
@@ -38,22 +37,46 @@ internal class CrudOperations<T : Any, ID : Any>(
                 auditingHandler.markModified(entity)
             }
         }
+        return isNew
+    }
 
-        return sessionProvider.write { session ->
-            if (isNew) {
-                session.persist(entity).replaceWith(entity)
-            } else {
-                session.merge(entity)
-            }
+    private fun save(
+        session: Mutiny.Session,
+        entity: T,
+        isNew: Boolean,
+    ): Uni<T> =
+        if (isNew) {
+            session.persist(entity).replaceWith(entity)
+        } else {
+            session.merge(entity)
         }
+
+    // ============================================
+    // Save 작업
+    // ============================================
+
+    suspend fun save(entity: T): T {
+        val isNew = prepareEntity(entity)
+
+        return sessionProvider.write { session -> save(session, entity, isNew) }
     }
 
     fun saveAll(entities: Iterable<T>): Flow<T> = flow {
         val entityList = entities.toList()
         if (entityList.isEmpty()) return@flow
 
-        val savedEntities = transactionExecutor.transactional {
-            entityList.map { save(it) }
+        val preparedEntities = entityList.map { entity ->
+            entity to prepareEntity(entity)
+        }
+        val savedEntities = sessionProvider.write { session ->
+            Multi.createFrom()
+                .iterable(preparedEntities)
+                .onItem()
+                .transformToUniAndConcatenate { (entity, isNew) ->
+                    save(session, entity, isNew)
+                }
+                .collect()
+                .asList()
         }
         emitAll(savedEntities.asFlow())
     }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
@@ -2,15 +2,22 @@ package io.clroot.hibernate.reactive.spring.boot.repository
 
 import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.isActive
+import jakarta.persistence.Id
+import org.hibernate.reactive.mutiny.Mutiny
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import java.lang.reflect.Proxy
 import kotlin.coroutines.EmptyCoroutineContext
@@ -182,11 +189,51 @@ class SimpleHibernateReactiveRepositoryTest : DescribeSpec({
                 capturedError!!.message shouldContain "save"
             }
         }
+
+        context("saveAll 트랜잭션 경계") {
+            it("모든 저장을 하나의 sessionProvider write 경계에서 실행한다") {
+                val localSessionProvider = mockk<TransactionalAwareSessionProvider>()
+                val localTransactionExecutor = mockk<ReactiveTransactionExecutor>()
+                val session = mockk<Mutiny.Session>()
+                var writeCalls = 0
+
+                coEvery {
+                    localSessionProvider.write<Any?>(any())
+                } coAnswers {
+                    writeCalls++
+                    firstArg<(Mutiny.Session) -> Uni<Any?>>()
+                        .invoke(session)
+                        .awaitSuspending()
+                }
+                coEvery {
+                    localTransactionExecutor.transactional<Any?>(any(), any())
+                } coAnswers {
+                    secondArg<suspend () -> Any?>().invoke()
+                }
+                every { session.persist(any()) } returns Uni.createFrom().voidItem()
+
+                val crud = CrudOperations<SaveAllEntity, Long>(
+                    entityClass = SaveAllEntity::class.java,
+                    sessionProvider = localSessionProvider,
+                    transactionExecutor = localTransactionExecutor,
+                    auditingHandler = null,
+                )
+
+                val saved = crud.saveAll(List(2_000) { SaveAllEntity() }).toList()
+
+                writeCalls shouldBe 1
+                saved.size shouldBe 2_000
+                coVerify(exactly = 0) {
+                    localTransactionExecutor.transactional<Any?>(any(), any())
+                }
+            }
+        }
     }
 }) {
     companion object {
         interface TestRepository : CoroutineCrudRepository<TestEntity, Long>
         class TestEntity
+        class SaveAllEntity(@Id val id: Long? = null)
 
         // 에러 메시지 테스트용 인터페이스 (오타가 포함된 메서드명)
         @Suppress("unused")


### PR DESCRIPTION
## Summary
- execute all `saveAll` operations through one `TransactionalAwareSessionProvider.write` boundary
- reuse active Spring/Core transactions instead of opening an unused nested transaction with a hidden 30-second timeout
- sequence persist/merge operations with a stack-safe Mutiny `Multi` while preserving input order
- cover Boot 3 and Boot 4 with a 2,000-entity regression test and assert no extra executor boundary

## Verification
- `JAVA_HOME=/Users/clroot/Library/Java/JavaVirtualMachines/temurin-17.0.17/Contents/Home ./gradlew clean build --no-build-cache`
- independent Spec review: no findings
- independent Standards review: no findings after large-batch fix