### PR TITLE
fix: avoid repository bean name collisions

### DIFF
--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryBeanNameGeneratorTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryBeanNameGeneratorTest.kt
@@ -1,0 +1,106 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.clroot.hibernate.reactive.spring.boot.repository.collision.alpha.OrderRepository as AlphaOrderRepository
+import io.clroot.hibernate.reactive.spring.boot.repository.collision.beta.OrderRepository as BetaOrderRepository
+import io.clroot.hibernate.reactive.spring.boot.repository.collision.customer.CustomerRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.support.RootBeanDefinition
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class HibernateReactiveRepositoryBeanNameGeneratorTest : DescribeSpec({
+    fun registerRepositories(
+        context: GenericApplicationContext,
+        vararg basePackages: String,
+    ) {
+        HibernateReactiveRepositoryRegistrar(basePackages.toList()).apply {
+            setApplicationContext(context)
+            postProcessBeanDefinitionRegistry(context)
+        }
+    }
+
+    describe("HibernateReactiveRepositoryBeanNameGenerator") {
+        it("유일한 리포지토리는 기존 단순 빈 이름을 유지한다") {
+            val repository = Alpha.CustomerRepository::class.java
+
+            HibernateReactiveRepositoryBeanNameGenerator.generate(listOf(repository)) { true }
+                .shouldContainExactly(mapOf(repository to "customerRepository"))
+        }
+
+        it("서로 다른 패키지 경로의 동명 리포지토리는 완전한 클래스명으로 구분한다") {
+            val first = Alpha.OrderRepository::class.java
+            val second = Beta.OrderRepository::class.java
+
+            HibernateReactiveRepositoryBeanNameGenerator.generate(listOf(first, second)) { true }
+                .shouldContainExactly(
+                    mapOf(
+                        first to first.name,
+                        second to second.name,
+                    ),
+                )
+        }
+
+        it("기존 빈이 단순 이름을 사용 중이면 완전한 클래스명으로 폴백한다") {
+            val repository = Alpha.CustomerRepository::class.java
+
+            HibernateReactiveRepositoryBeanNameGenerator.generate(listOf(repository)) {
+                it != "customerRepository"
+            }.shouldContainExactly(mapOf(repository to repository.name))
+        }
+
+        it("서로 다른 실제 패키지의 동명 리포지토리를 함께 등록한다") {
+            GenericApplicationContext().use { context ->
+                registerRepositories(
+                    context,
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.alpha",
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.beta",
+                )
+
+                context.containsBeanDefinition(AlphaOrderRepository::class.java.name) shouldBe true
+                context.containsBeanDefinition(BetaOrderRepository::class.java.name) shouldBe true
+            }
+        }
+
+        it("alias가 단순 이름을 점유하면 완전한 클래스명으로 등록한다") {
+            GenericApplicationContext().use { context ->
+                context.registerBeanDefinition("existingBean", RootBeanDefinition(Any::class.java))
+                context.registerAlias("existingBean", "customerRepository")
+
+                registerRepositories(
+                    context,
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.customer",
+                )
+
+                context.isAlias("customerRepository") shouldBe true
+                context.containsBeanDefinition(CustomerRepository::class.java.name) shouldBe true
+            }
+        }
+
+        it("수동 singleton이 단순 이름을 점유하면 완전한 클래스명으로 등록한다") {
+            GenericApplicationContext().use { context ->
+                context.beanFactory.registerSingleton("customerRepository", Any())
+
+                registerRepositories(
+                    context,
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.customer",
+                )
+
+                context.containsBeanDefinition(CustomerRepository::class.java.name) shouldBe true
+            }
+        }
+    }
+
+}) {
+    private class TestEntity
+
+    private object Alpha {
+        interface CustomerRepository : CoroutineCrudRepository<TestEntity, Long>
+        interface OrderRepository : CoroutineCrudRepository<TestEntity, Long>
+    }
+
+    private object Beta {
+        interface OrderRepository : CoroutineCrudRepository<TestEntity, Long>
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/alpha/OrderRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/alpha/OrderRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.collision.alpha
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class AlphaOrder
+
+interface OrderRepository : CoroutineCrudRepository<AlphaOrder, Long>

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/beta/OrderRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/beta/OrderRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.collision.beta
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class BetaOrder
+
+interface OrderRepository : CoroutineCrudRepository<BetaOrder, Long>

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/customer/CustomerRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/customer/CustomerRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.collision.customer
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class Customer
+
+interface CustomerRepository : CoroutineCrudRepository<Customer, Long>

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryRegistrar.kt
@@ -34,9 +34,12 @@ public class HibernateReactiveRepositoryRegistrar(
         }
 
         val repositoryInterfaces = findRepositoryInterfaces(packagesToScan)
+        val beanNames = HibernateReactiveRepositoryBeanNameGenerator.generate(repositoryInterfaces) { beanName ->
+            !registry.isBeanNameInUse(beanName)
+        }
 
         repositoryInterfaces.forEach { repositoryInterface ->
-            val beanName = generateBeanName(repositoryInterface)
+            val beanName = beanNames.getValue(repositoryInterface)
             val beanDefinition = createBeanDefinition(repositoryInterface)
 
             registry.registerBeanDefinition(beanName, beanDefinition)
@@ -83,11 +86,34 @@ public class HibernateReactiveRepositoryRegistrar(
             .beanDefinition
     }
 
-    /**
-     * Bean 이름을 생성합니다. (예: UserRepository → userRepository)
-     */
-    private fun generateBeanName(repositoryInterface: Class<*>): String {
-        val simpleName = repositoryInterface.simpleName
-        return simpleName.replaceFirstChar { it.lowercase() }
+}
+
+internal object HibernateReactiveRepositoryBeanNameGenerator {
+    fun generate(
+        repositoryInterfaces: List<Class<*>>,
+        isNameAvailable: (String) -> Boolean,
+    ): Map<Class<*>, String> {
+        val conventionalNames = repositoryInterfaces.associateWith { repositoryInterface ->
+            repositoryInterface.simpleName.replaceFirstChar { it.lowercase() }
+        }
+        val duplicateNames = conventionalNames.values
+            .groupingBy { it }
+            .eachCount()
+            .filterValues { it > 1 }
+            .keys
+
+        return repositoryInterfaces.associateWith { repositoryInterface ->
+            val conventionalName = conventionalNames.getValue(repositoryInterface)
+            val beanName = if (conventionalName in duplicateNames || !isNameAvailable(conventionalName)) {
+                repositoryInterface.name
+            } else {
+                conventionalName
+            }
+
+            check(isNameAvailable(beanName)) {
+                "Cannot register repository '${repositoryInterface.name}': bean name '$beanName' is already in use"
+            }
+            beanName
+        }
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryBeanNameGeneratorTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryBeanNameGeneratorTest.kt
@@ -1,0 +1,106 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.clroot.hibernate.reactive.spring.boot.repository.collision.alpha.OrderRepository as AlphaOrderRepository
+import io.clroot.hibernate.reactive.spring.boot.repository.collision.beta.OrderRepository as BetaOrderRepository
+import io.clroot.hibernate.reactive.spring.boot.repository.collision.customer.CustomerRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.support.RootBeanDefinition
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class HibernateReactiveRepositoryBeanNameGeneratorTest : DescribeSpec({
+    fun registerRepositories(
+        context: GenericApplicationContext,
+        vararg basePackages: String,
+    ) {
+        HibernateReactiveRepositoryRegistrar(basePackages.toList()).apply {
+            setApplicationContext(context)
+            postProcessBeanDefinitionRegistry(context)
+        }
+    }
+
+    describe("HibernateReactiveRepositoryBeanNameGenerator") {
+        it("유일한 리포지토리는 기존 단순 빈 이름을 유지한다") {
+            val repository = Alpha.CustomerRepository::class.java
+
+            HibernateReactiveRepositoryBeanNameGenerator.generate(listOf(repository)) { true }
+                .shouldContainExactly(mapOf(repository to "customerRepository"))
+        }
+
+        it("서로 다른 패키지 경로의 동명 리포지토리는 완전한 클래스명으로 구분한다") {
+            val first = Alpha.OrderRepository::class.java
+            val second = Beta.OrderRepository::class.java
+
+            HibernateReactiveRepositoryBeanNameGenerator.generate(listOf(first, second)) { true }
+                .shouldContainExactly(
+                    mapOf(
+                        first to first.name,
+                        second to second.name,
+                    ),
+                )
+        }
+
+        it("기존 빈이 단순 이름을 사용 중이면 완전한 클래스명으로 폴백한다") {
+            val repository = Alpha.CustomerRepository::class.java
+
+            HibernateReactiveRepositoryBeanNameGenerator.generate(listOf(repository)) {
+                it != "customerRepository"
+            }.shouldContainExactly(mapOf(repository to repository.name))
+        }
+
+        it("서로 다른 실제 패키지의 동명 리포지토리를 함께 등록한다") {
+            GenericApplicationContext().use { context ->
+                registerRepositories(
+                    context,
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.alpha",
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.beta",
+                )
+
+                context.containsBeanDefinition(AlphaOrderRepository::class.java.name) shouldBe true
+                context.containsBeanDefinition(BetaOrderRepository::class.java.name) shouldBe true
+            }
+        }
+
+        it("alias가 단순 이름을 점유하면 완전한 클래스명으로 등록한다") {
+            GenericApplicationContext().use { context ->
+                context.registerBeanDefinition("existingBean", RootBeanDefinition(Any::class.java))
+                context.registerAlias("existingBean", "customerRepository")
+
+                registerRepositories(
+                    context,
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.customer",
+                )
+
+                context.isAlias("customerRepository") shouldBe true
+                context.containsBeanDefinition(CustomerRepository::class.java.name) shouldBe true
+            }
+        }
+
+        it("수동 singleton이 단순 이름을 점유하면 완전한 클래스명으로 등록한다") {
+            GenericApplicationContext().use { context ->
+                context.beanFactory.registerSingleton("customerRepository", Any())
+
+                registerRepositories(
+                    context,
+                    "io.clroot.hibernate.reactive.spring.boot.repository.collision.customer",
+                )
+
+                context.containsBeanDefinition(CustomerRepository::class.java.name) shouldBe true
+            }
+        }
+    }
+
+}) {
+    private class TestEntity
+
+    private object Alpha {
+        interface CustomerRepository : CoroutineCrudRepository<TestEntity, Long>
+        interface OrderRepository : CoroutineCrudRepository<TestEntity, Long>
+    }
+
+    private object Beta {
+        interface OrderRepository : CoroutineCrudRepository<TestEntity, Long>
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/alpha/OrderRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/alpha/OrderRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.collision.alpha
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class AlphaOrder
+
+interface OrderRepository : CoroutineCrudRepository<AlphaOrder, Long>

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/beta/OrderRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/beta/OrderRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.collision.beta
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class BetaOrder
+
+interface OrderRepository : CoroutineCrudRepository<BetaOrder, Long>

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/customer/CustomerRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/collision/customer/CustomerRepository.kt
@@ -1,0 +1,7 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.collision.customer
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+class Customer
+
+interface CustomerRepository : CoroutineCrudRepository<Customer, Long>


### PR DESCRIPTION
## Summary
- preserve conventional lower-camel bean names for unique repositories
- use fully qualified repository names for same-simple-name interfaces or occupied conventional names
- account for bean definitions, aliases, and manually registered singletons via `isBeanNameInUse`
- add Boot 3/4 scanner and registrar tests with repositories in distinct packages

## Verification
- JDK 17 `./gradlew clean build --no-build-cache`
- independent Spec review: no findings
- independent Standards review: no findings after alias/singleton and real-package coverage