### PR TITLE
fix: support Long auditing timestamps

### DIFF
--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/LongAuditingDateTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/LongAuditingDateTest.kt
@@ -1,0 +1,80 @@
+package io.clroot.hibernate.reactive.spring.boot.auditing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+
+class LongAuditingDateTest : DescribeSpec({
+    val listener = AuditingEntityListener()
+
+    describe("Long auditing dates") {
+        it("nullable Long 날짜 필드를 epoch milliseconds로 설정한다") {
+            val entity = NullableLongDates()
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt.shouldNotBeNull() shouldBeGreaterThan 0L
+            entity.updatedAt.shouldNotBeNull() shouldBeGreaterThan 0L
+        }
+
+        it("non-null Long의 초기값 0을 epoch milliseconds로 교체한다") {
+            val entity = NonNullLongDates()
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt shouldBeGreaterThan 0L
+            entity.updatedAt shouldBeGreaterThan 0L
+        }
+
+        it("명시적으로 설정된 nullable Long 생성 시각은 보존한다") {
+            val entity = NullableLongDates(createdAt = 123L)
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt shouldBe 123L
+        }
+
+        it("명시적으로 설정된 non-null Long 생성 시각은 보존한다") {
+            val entity = NonNullLongDates(createdAt = 123L)
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt shouldBe 123L
+        }
+
+        it("nullable Long 수정 시각을 갱신한다") {
+            val entity = NullableLongDates(createdAt = 123L, updatedAt = 123L)
+
+            listener.onPreUpdate(entity)
+
+            entity.createdAt shouldBe 123L
+            entity.updatedAt.shouldNotBeNull() shouldBeGreaterThan 123L
+        }
+
+        it("non-null Long 수정 시각을 갱신하고 생성 시각은 보존한다") {
+            val entity = NonNullLongDates(createdAt = 123L, updatedAt = 123L)
+
+            listener.onPreUpdate(entity)
+
+            entity.createdAt shouldBe 123L
+            entity.updatedAt shouldBeGreaterThan 123L
+        }
+    }
+}) {
+    private class NullableLongDates(
+        @CreatedDate
+        var createdAt: Long? = null,
+        @LastModifiedDate
+        var updatedAt: Long? = null,
+    )
+
+    private class NonNullLongDates(
+        @CreatedDate
+        var createdAt: Long = 0,
+        @LastModifiedDate
+        var updatedAt: Long = 0,
+    )
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
@@ -40,7 +40,10 @@ internal object AuditMetadata {
     fun setCreatedDate(entity: Any) {
         val auditInfo = getAuditInfo(entity.javaClass)
         auditInfo.createdDateField?.let { field ->
-            if (getFieldValueSafely(entity, field) == null) {
+            val currentValue = getFieldValueSafely(entity, field)
+            val isUnsetPrimitiveLong =
+                field.type == Long::class.javaPrimitiveType && currentValue == 0L
+            if (currentValue == null || isUnsetPrimitiveLong) {
                 setTemporalValue(entity, field)
             }
         }
@@ -120,7 +123,7 @@ internal object AuditMetadata {
             LocalDateTime::class.java -> LocalDateTime.now()
             ZonedDateTime::class.java -> ZonedDateTime.now()
             Date::class.java -> Date()
-            Long::class.java, Long::class.javaPrimitiveType -> System.currentTimeMillis()
+            Long::class.javaObjectType, Long::class.javaPrimitiveType -> System.currentTimeMillis()
             else -> return // 지원하지 않는 타입
         }
         setFieldValueSafely(entity, field, value)
@@ -211,7 +214,7 @@ internal object AuditMetadata {
                 type == LocalDateTime::class.java ||
                 type == ZonedDateTime::class.java ||
                 type == Date::class.java ||
-                type == Long::class.java ||
+                type == Long::class.javaObjectType ||
                 type == Long::class.javaPrimitiveType
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/LongAuditingDateTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/LongAuditingDateTest.kt
@@ -1,0 +1,80 @@
+package io.clroot.hibernate.reactive.spring.boot.auditing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+
+class LongAuditingDateTest : DescribeSpec({
+    val listener = AuditingEntityListener()
+
+    describe("Long auditing dates") {
+        it("nullable Long 날짜 필드를 epoch milliseconds로 설정한다") {
+            val entity = NullableLongDates()
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt.shouldNotBeNull() shouldBeGreaterThan 0L
+            entity.updatedAt.shouldNotBeNull() shouldBeGreaterThan 0L
+        }
+
+        it("non-null Long의 초기값 0을 epoch milliseconds로 교체한다") {
+            val entity = NonNullLongDates()
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt shouldBeGreaterThan 0L
+            entity.updatedAt shouldBeGreaterThan 0L
+        }
+
+        it("명시적으로 설정된 nullable Long 생성 시각은 보존한다") {
+            val entity = NullableLongDates(createdAt = 123L)
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt shouldBe 123L
+        }
+
+        it("명시적으로 설정된 non-null Long 생성 시각은 보존한다") {
+            val entity = NonNullLongDates(createdAt = 123L)
+
+            listener.onPrePersist(entity)
+
+            entity.createdAt shouldBe 123L
+        }
+
+        it("nullable Long 수정 시각을 갱신한다") {
+            val entity = NullableLongDates(createdAt = 123L, updatedAt = 123L)
+
+            listener.onPreUpdate(entity)
+
+            entity.createdAt shouldBe 123L
+            entity.updatedAt.shouldNotBeNull() shouldBeGreaterThan 123L
+        }
+
+        it("non-null Long 수정 시각을 갱신하고 생성 시각은 보존한다") {
+            val entity = NonNullLongDates(createdAt = 123L, updatedAt = 123L)
+
+            listener.onPreUpdate(entity)
+
+            entity.createdAt shouldBe 123L
+            entity.updatedAt shouldBeGreaterThan 123L
+        }
+    }
+}) {
+    private class NullableLongDates(
+        @CreatedDate
+        var createdAt: Long? = null,
+        @LastModifiedDate
+        var updatedAt: Long? = null,
+    )
+
+    private class NonNullLongDates(
+        @CreatedDate
+        var createdAt: Long = 0,
+        @LastModifiedDate
+        var updatedAt: Long = 0,
+    )
+}


### PR DESCRIPTION
## Summary
- recognize boxed Kotlin `Long?` auditing fields as supported temporal types
- treat primitive `Long` zero as the unset sentinel for `@CreatedDate`
- preserve explicitly supplied nonzero created timestamps
- cover persist and update behavior for boxed and primitive Long in Boot 3 and Boot 4

## Verification
- JDK 17 `./gradlew clean build --no-build-cache`
- Boot 3/4 focused suites: 6 tests each
- independent Spec review: no findings
- independent Standards review: no findings