### PR TITLE
fix: reject read-only transaction upgrades

### DIFF
--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
@@ -53,8 +53,10 @@ public class ReactiveTransactionExecutor(
      *
      * 블록 내 모든 Port 호출이 동일한 세션을 공유하며,
      * 이미 트랜잭션 컨텍스트 안에 있으면 기존 세션을 재사용합니다 (중첩 안전).
+     * 단, 읽기 전용 컨텍스트는 쓰기 트랜잭션으로 승격할 수 없습니다.
      *
      * @param timeout 트랜잭션 타임아웃 (기본 30초). 중첩 시 부모의 남은 시간과 비교하여 더 짧은 값 적용.
+     * @throws ReadOnlyTransactionException 읽기 전용 컨텍스트 안에서 호출한 경우
      */
     public suspend fun <T> transactional(
         timeout: Duration = DEFAULT_TIMEOUT,
@@ -110,6 +112,13 @@ public class ReactiveTransactionExecutor(
         block: suspend () -> T,
     ): T {
         val parentContext = currentContextOrNull()
+        if (mode == TransactionMode.READ_WRITE && parentContext?.isReadOnly == true) {
+            throw ReadOnlyTransactionException(
+                "Cannot start a write transaction within a read-only context. " +
+                        "Move tx.transactional {} outside tx.readOnly {}",
+            )
+        }
+
         val effectiveTimeout = calculateEffectiveTimeout(parentContext, timeout)
         val callerContext = currentCoroutineContext().minusKey(Job)
 

--- a/hibernate-reactive-coroutines-core/src/test/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutorTest.kt
+++ b/hibernate-reactive-coroutines-core/src/test/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutorTest.kt
@@ -1,6 +1,7 @@
 package io.clroot.hibernate.reactive
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import kotlinx.coroutines.withContext
@@ -87,30 +88,41 @@ class ReactiveTransactionExecutorTest : DescribeSpec({
         context("컨텍스트 재사용 (REQUIRED 동작)") {
             it("기존 READ_WRITE 컨텍스트가 있으면 새 트랜잭션을 생성하지 않는다") {
                 val session = mockk<org.hibernate.reactive.mutiny.Mutiny.Session>()
+                val sessionFactory = mockk<org.hibernate.reactive.mutiny.Mutiny.SessionFactory>()
+                val executor = ReactiveTransactionExecutor(sessionFactory)
                 val existingContext = ReactiveSessionContext(
                     session = session,
                     mode = TransactionMode.READ_WRITE,
                 )
 
-                withContext(existingContext) {
-                    // transactional 블록 진입 시 parentContext가 null이 아니면
-                    // 새 트랜잭션 없이 기존 세션 재사용
-                    currentContextOrNull() shouldBe existingContext
-                    currentSessionOrNull() shouldBe session
+                val actualSession = withContext(existingContext) {
+                    executor.transactional {
+                        currentSessionOrNull()
+                    }
                 }
+
+                actualSession shouldBe session
             }
 
-            it("기존 READ_ONLY 컨텍스트도 재사용한다") {
+            it("READ_ONLY 컨텍스트를 쓰기 트랜잭션으로 승격하지 않는다") {
                 val session = mockk<org.hibernate.reactive.mutiny.Mutiny.Session>()
+                val sessionFactory = mockk<org.hibernate.reactive.mutiny.Mutiny.SessionFactory>()
+                val executor = ReactiveTransactionExecutor(sessionFactory)
                 val existingContext = ReactiveSessionContext(
                     session = session,
                     mode = TransactionMode.READ_ONLY,
                 )
+                var blockExecuted = false
 
                 withContext(existingContext) {
-                    currentContextOrNull() shouldBe existingContext
-                    currentContextOrNull()?.isReadOnly shouldBe true
+                    shouldThrow<ReadOnlyTransactionException> {
+                        executor.transactional {
+                            blockExecuted = true
+                        }
+                    }
                 }
+
+                blockExecuted shouldBe false
             }
         }
 


### PR DESCRIPTION
## Summary
- reject `transactional` calls nested inside a read-only session before executing user code
- preserve REQUIRED reuse for nested read-write transactions
- replace a context-only test with public executor behavior coverage

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew clean check`
- independent Spec and Standards reviews of commit `00685bbc655c97f09a61e3ab73de63478d47ad68`: no findings