### PR TITLE
feat: support reactive transactional events

### DIFF
--- a/docs/usage-guide.ko.md
+++ b/docs/usage-guide.ko.md
@@ -246,6 +246,37 @@ class UserService(private val userRepository: UserRepository) {
 }
 ```
 
+### 트랜잭션 이벤트
+
+starter는 Spring의 reactive `TransactionalEventPublisher`를 자동 구성합니다. Reactive
+트랜잭션 안에서는 `ApplicationEventPublisher` 대신 이 publisher를 사용해야
+`@TransactionalEventListener`가 요구하는 Reactor 트랜잭션 컨텍스트가 이벤트에 포함됩니다.
+
+```kotlin
+@Service
+class OrderService(
+    private val events: TransactionalEventPublisher,
+) {
+    @Transactional
+    suspend fun placeOrder(command: PlaceOrderCommand) {
+        // 주문을 먼저 저장한 뒤...
+        events.publishEvent(OrderPlaced(command.orderId)).awaitSingleOrNull()
+    }
+}
+
+@Component
+class OrderPlacedHandler {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun afterCommit(event: OrderPlaced) {
+        // 커밋에 성공한 뒤에만 실행됩니다.
+    }
+}
+```
+
+반환되는 `Mono`는 트랜잭션 suspend 함수 안에서 반드시 await해야 합니다. 일반
+`ApplicationEventPublisher`로 발행하거나 reactive publisher를 별도로 subscribe하면
+reactive 트랜잭션 컨텍스트가 끊겨 after-commit 콜백이 등록되지 않습니다.
+
 ### ReactiveTransactionExecutor
 
 프로그래매틱하게 트랜잭션을 관리할 수도 있습니다.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -249,6 +249,37 @@ class UserService(private val userRepository: UserRepository) {
 }
 ```
 
+### Transactional Events
+
+The starter auto-configures Spring's reactive `TransactionalEventPublisher`. Use it instead of
+`ApplicationEventPublisher` inside reactive transactions so the event carries the Reactor
+transaction context required by `@TransactionalEventListener`.
+
+```kotlin
+@Service
+class OrderService(
+    private val events: TransactionalEventPublisher,
+) {
+    @Transactional
+    suspend fun placeOrder(command: PlaceOrderCommand) {
+        // Persist the order first...
+        events.publishEvent(OrderPlaced(command.orderId)).awaitSingleOrNull()
+    }
+}
+
+@Component
+class OrderPlacedHandler {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun afterCommit(event: OrderPlaced) {
+        // Runs only after a successful commit.
+    }
+}
+```
+
+The returned `Mono` must be awaited inside the transactional suspend function. Publishing through
+the regular `ApplicationEventPublisher`, or subscribing to the reactive publisher separately,
+loses the reactive transaction context and does not register the after-commit callback.
+
 ### ReactiveTransactionExecutor
 
 Manage transactions programmatically.

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/api/hibernate-reactive-coroutines-spring-boot-starter-boot4.api
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/api/hibernate-reactive-coroutines-spring-boot-starter-boot4.api
@@ -28,6 +28,7 @@ public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateRea
 	public fun reactiveSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveSessionProvider;
 	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
 	public fun transactionalAwareSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+	public fun transactionalEventPublisher (Lorg/springframework/context/ApplicationEventPublisher;)Lorg/springframework/transaction/reactive/TransactionalEventPublisher;
 }
 
 public final class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties {

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionalEventIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionalEventIntegrationTest.kt
@@ -1,0 +1,91 @@
+package io.clroot.hibernate.reactive.test
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.transaction.reactive.TransactionalEventPublisher
+import java.util.concurrent.CopyOnWriteArrayList
+
+@SpringBootTest(
+    classes = [
+        TestApplication::class,
+        TransactionalEventIntegrationTest.EventTestConfiguration::class,
+    ],
+)
+class TransactionalEventIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var service: EventPublishingService
+
+    @Autowired
+    private lateinit var listener: TransactionalEventRecorder
+
+    init {
+        beforeEach {
+            listener.events.clear()
+        }
+
+        describe("reactive transactional events") {
+            it("AFTER_COMMIT listener를 커밋 후 호출한다") {
+                service.publish("committed")
+
+                listener.events shouldContainExactly listOf("committed")
+            }
+
+            it("롤백된 트랜잭션의 AFTER_COMMIT listener는 호출하지 않는다") {
+                shouldThrow<ExpectedRollbackException> {
+                    service.publishAndRollback("rolled-back")
+                }
+
+                listener.events shouldContainExactly emptyList()
+            }
+        }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    class EventTestConfiguration {
+        @Bean
+        fun eventPublishingService(
+            publisher: TransactionalEventPublisher,
+        ): EventPublishingService = EventPublishingService(publisher)
+
+        @Bean
+        fun transactionalEventRecorder(): TransactionalEventRecorder = TransactionalEventRecorder()
+    }
+
+    open class EventPublishingService(
+        private val publisher: TransactionalEventPublisher,
+    ) {
+        @Transactional
+        open suspend fun publish(value: String) {
+            publisher.publishEvent(CommittedEvent(value)).awaitSingleOrNull()
+        }
+
+        @Transactional
+        open suspend fun publishAndRollback(value: String) {
+            publisher.publishEvent(CommittedEvent(value)).awaitSingleOrNull()
+            throw ExpectedRollbackException()
+        }
+    }
+
+    class TransactionalEventRecorder {
+        val events: MutableList<String> = CopyOnWriteArrayList()
+
+        @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+        fun onCommitted(event: CommittedEvent) {
+            events += event.value
+        }
+    }
+
+    data class CommittedEvent(
+        val value: String,
+    )
+
+    class ExpectedRollbackException : RuntimeException()
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
@@ -17,9 +17,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.transaction.reactive.TransactionalEventPublisher
 
 /**
  * Hibernate Reactive Auto-configuration.
@@ -28,6 +30,7 @@ import org.springframework.core.type.filter.AnnotationTypeFilter
  * - [Mutiny.SessionFactory]: Hibernate Reactive 세션 팩토리
  * - [ReactiveSessionProvider]: Adapter에서 사용하는 세션 헬퍼
  * - [ReactiveTransactionExecutor]: Service에서 사용하는 트랜잭션 래퍼
+ * - [TransactionalEventPublisher]: reactive 트랜잭션 이벤트 발행기
  *
  * @Entity 클래스는 @SpringBootApplication 패키지 기준으로 자동 스캔됩니다.
  *
@@ -270,6 +273,13 @@ public class HibernateReactiveAutoConfiguration(
         reactiveSessionFactory: Mutiny.SessionFactory,
     ): HibernateReactiveTransactionManager =
         HibernateReactiveTransactionManager(reactiveSessionFactory)
+
+    @Bean
+    @ConditionalOnMissingBean
+    public fun transactionalEventPublisher(
+        applicationEventPublisher: ApplicationEventPublisher,
+    ): TransactionalEventPublisher =
+        TransactionalEventPublisher(applicationEventPublisher)
 
     @Bean
     @ConditionalOnMissingBean

--- a/hibernate-reactive-coroutines-spring-boot-starter/api/hibernate-reactive-coroutines-spring-boot-starter.api
+++ b/hibernate-reactive-coroutines-spring-boot-starter/api/hibernate-reactive-coroutines-spring-boot-starter.api
@@ -28,6 +28,7 @@ public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateRea
 	public fun reactiveSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveSessionProvider;
 	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
 	public fun transactionalAwareSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
+	public fun transactionalEventPublisher (Lorg/springframework/context/ApplicationEventPublisher;)Lorg/springframework/transaction/reactive/TransactionalEventPublisher;
 }
 
 public final class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties {

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionalEventIntegrationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/TransactionalEventIntegrationTest.kt
@@ -1,0 +1,91 @@
+package io.clroot.hibernate.reactive.test
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.transaction.reactive.TransactionalEventPublisher
+import java.util.concurrent.CopyOnWriteArrayList
+
+@SpringBootTest(
+    classes = [
+        TestApplication::class,
+        TransactionalEventIntegrationTest.EventTestConfiguration::class,
+    ],
+)
+class TransactionalEventIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var service: EventPublishingService
+
+    @Autowired
+    private lateinit var listener: TransactionalEventRecorder
+
+    init {
+        beforeEach {
+            listener.events.clear()
+        }
+
+        describe("reactive transactional events") {
+            it("AFTER_COMMIT listener를 커밋 후 호출한다") {
+                service.publish("committed")
+
+                listener.events shouldContainExactly listOf("committed")
+            }
+
+            it("롤백된 트랜잭션의 AFTER_COMMIT listener는 호출하지 않는다") {
+                shouldThrow<ExpectedRollbackException> {
+                    service.publishAndRollback("rolled-back")
+                }
+
+                listener.events shouldContainExactly emptyList()
+            }
+        }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    class EventTestConfiguration {
+        @Bean
+        fun eventPublishingService(
+            publisher: TransactionalEventPublisher,
+        ): EventPublishingService = EventPublishingService(publisher)
+
+        @Bean
+        fun transactionalEventRecorder(): TransactionalEventRecorder = TransactionalEventRecorder()
+    }
+
+    open class EventPublishingService(
+        private val publisher: TransactionalEventPublisher,
+    ) {
+        @Transactional
+        open suspend fun publish(value: String) {
+            publisher.publishEvent(CommittedEvent(value)).awaitSingleOrNull()
+        }
+
+        @Transactional
+        open suspend fun publishAndRollback(value: String) {
+            publisher.publishEvent(CommittedEvent(value)).awaitSingleOrNull()
+            throw ExpectedRollbackException()
+        }
+    }
+
+    class TransactionalEventRecorder {
+        val events: MutableList<String> = CopyOnWriteArrayList()
+
+        @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+        fun onCommitted(event: CommittedEvent) {
+            events += event.value
+        }
+    }
+
+    data class CommittedEvent(
+        val value: String,
+    )
+
+    class ExpectedRollbackException : RuntimeException()
+}


### PR DESCRIPTION
## Summary
- auto-configure Spring reactive `TransactionalEventPublisher` with user-bean backoff
- verify `AFTER_COMMIT` delivery after commit and suppression after rollback on Boot 3/4
- document the required awaited publisher pattern in English and Korean
- update both starter ABI snapshots

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew clean check`
- independent Spec and Standards reviews of `9a1a18fca03b70512b463ab7d06efbd55dfea04a`: no findings