### PR TITLE
fix: address production-readiness gaps across query, transaction and config layers

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -24,6 +24,12 @@ Hibernate Reactive + Kotlin Coroutines 환경에서 Spring Data JPA의 편의성
 - Java 17 이상
 - Spring Boot 3.4.x 또는 4.x
 
+> **Hibernate ORM 7이 필요합니다.** Hibernate Reactive 3.1은 Hibernate ORM 7.1 위에서 동작하며,
+> 이 스타터는 해당 버전을 의존성 제약으로 발행합니다. Spring Framework 6.x(Spring Boot 3.x)는
+> Hibernate ORM 7을 지원하지 않으므로, **Spring Boot 3 애플리케이션에서 `spring-boot-starter-data-jpa`와
+> 함께 사용하지 마세요** — 블로킹 JPA 쪽이 기동에 실패합니다. Spring Boot 4에서는 공존할 수 있습니다.
+> Boot 3에서 둘 다 필요하다면 리액티브 영속성 계층과 블로킹 영속성 계층을 별도 모듈로 분리하세요.
+
 ## 설치
 
 ### Gradle (Kotlin DSL)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ This library provides a **Spring Boot starter for Hibernate Reactive** with firs
 - Java 17 or later
 - Spring Boot 3.4.x or 4.x
 
+> **Hibernate ORM 7 is required.** Hibernate Reactive 3.1 runs on Hibernate ORM 7.1, and this starter
+> publishes that as a dependency constraint. Because Spring Framework 6.x (Spring Boot 3.x) does not
+> support Hibernate ORM 7, **do not combine this starter with `spring-boot-starter-data-jpa` in a
+> Spring Boot 3 application** — the blocking JPA half will fail to start. On Spring Boot 4 the two can
+> coexist. Run the reactive and blocking persistence layers in separate modules if you need both on
+> Boot 3.
+
 ## Installation
 
 ### Gradle (Kotlin DSL)

--- a/docs/migration.ko.md
+++ b/docs/migration.ko.md
@@ -49,13 +49,56 @@ Spring Data JPA에서 Hibernate Reactive Coroutines로 전환하는 가이드입
 
 ### 미지원 기능
 
-| 기능                         | 대체 방안                        |
-| ---------------------------- | -------------------------------- |
-| Specification (동적 쿼리)    | `@Query`로 직접 작성             |
-| QueryByExample               | 조건별 메서드 조합               |
-| Projection (인터페이스 기반) | `SELECT new DTO(...)` 사용       |
-| `@EntityGraph`               | FETCH JOIN 또는 `fetch()` 메서드 |
-| Native @Modifying            | JPQL 사용                        |
+아래 항목들은 첫 호출 시점이 아니라 **애플리케이션 기동 시점에** 원인을 설명하는 메시지와 함께 거부됩니다.
+
+| 기능                                 | 대체 방안                                                   |
+| ------------------------------------ | ----------------------------------------------------------- |
+| Specification (동적 쿼리)            | `@Query`로 직접 작성                                        |
+| QueryByExample                       | 조건별 메서드 조합                                          |
+| Projection (인터페이스 기반)         | FETCH JOIN 후 Kotlin에서 매핑                               |
+| `@EntityGraph`                       | FETCH JOIN 또는 `fetch()` 메서드                            |
+| Native `@Modifying`                  | JPQL 사용                                                   |
+| `@Query`의 스칼라/집계/DTO 반환      | 엔티티 타입 반환, 또는 `count…`/`exists…` 파생 메서드 사용  |
+| suspend가 아닌(`Flow` 포함) 쿼리 메서드 | `suspend fun … : List<T>` 로 선언                        |
+| 이름과 인자 개수가 같은 오버로드     | 서로 다른 이름 사용                                         |
+| `Top`/`First` + `Pageable` 조합      | 둘 중 하나만 사용                                           |
+| 네이티브 `@Query` 정렬               | 쿼리 안에 `ORDER BY` 작성                                   |
+
+---
+
+## 동작 상 주의점
+
+위 기능 표 외에, 마이그레이션 전에 알아둘 동작 차이입니다.
+
+**삭제는 조회 후 제거합니다.** `deleteById`, `delete`, `deleteAll`, `deleteAllById`와 파생
+`deleteBy…` 메서드는 대상 엔티티를 조회한 뒤 하나씩 제거합니다(`SimpleJpaRepository`와 동일).
+따라서 cascade, `@Version` 검사, `@PreRemove` 콜백이 모두 동작하고 영속성 컨텍스트도 일관되게
+유지됩니다. 대신 `DELETE` 전에 `SELECT`가 한 번 실행됩니다. cascade 없이 대량 삭제가 필요하면
+`@Modifying @Query("DELETE …")`를 명시적으로 작성하세요.
+
+**파생 `deleteBy…`는 삭제 건수를 반환할 수 있습니다.** 반환 타입을 `Unit`, `Int`, `Long` 중 하나로
+선언하면 됩니다.
+
+**`LIKE` 값은 이스케이프됩니다.** `Containing`, `StartingWith`, `EndingWith`는 바인딩되는 값의
+`%`, `_`, `\`를 이스케이프하므로 `findByNameContaining("%")`는 전체 행이 아니라 퍼센트 문자를
+포함한 행만 매칭합니다. 명시적 `Like` 키워드는 사용자가 직접 패턴을 넘기는 것이므로
+이스케이프하지 않습니다.
+
+**`IgnoreCase`는 양쪽을 소문자로 비교합니다.** String이 아닌 프로퍼티에 `IgnoreCase`를 쓰면 기동
+시점에 거부되고, `AllIgnoreCase`는 String 프로퍼티에만 적용됩니다.
+
+**`Sort`가 `@Query` 메서드에도 적용됩니다.** `Sort` 파라미터나 정렬이 담긴 `Pageable`은 쿼리에
+이미 있는 `ORDER BY` 뒤에 덧붙습니다. 즉 쿼리에 작성한 정렬이 우선합니다.
+
+**엔티티 이름은 JPA 메타모델에서 가져옵니다.** `@Entity(name = "…")`으로 이름을 바꾼 엔티티나
+패키지가 다른 동명 엔티티도 정상 동작합니다.
+
+**`Flow`는 스트리밍이 아닙니다.** `findAll()` 등 `Flow`를 반환하는 메서드는 전체 결과를 메모리에
+적재한 뒤 방출합니다. 큰 테이블에는 `Pageable`을 사용하세요.
+
+**`@Transactional`과 `tx.transactional {}`을 섞어 써도 안전합니다.** `tx.transactional {}`은 활성
+Spring 트랜잭션이 있으면 새 세션을 열지 않고 그 트랜잭션에 참여하며,
+`@Transactional(readOnly = true)` 트랜잭션을 쓰기로 승격하려 하면 예외를 던집니다.
 
 ---
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -51,13 +51,54 @@ query-level pagination, and parameterized ordering require an explicit `countQue
 
 ### Unsupported Features
 
-| Feature                         | Alternative                    |
-| ------------------------------- | ------------------------------ |
-| Specification (dynamic queries) | Write directly with `@Query`   |
-| QueryByExample                  | Combine conditional methods    |
-| Projection (interface-based)    | Use `SELECT new DTO(...)`      |
-| `@EntityGraph`                  | FETCH JOIN or `fetch()` method |
-| Native @Modifying               | Use JPQL instead               |
+These are rejected at application startup with an explanatory message, not at first call.
+
+| Feature                                   | Alternative                                     |
+| ----------------------------------------- | ----------------------------------------------- |
+| Specification (dynamic queries)           | Write directly with `@Query`                    |
+| QueryByExample                            | Combine conditional methods                     |
+| Projection (interface-based)              | Use FETCH JOIN and map in Kotlin                |
+| `@EntityGraph`                            | FETCH JOIN or `fetch()` method                  |
+| Native `@Modifying`                       | Use JPQL instead                                |
+| Scalar/aggregate/DTO results in `@Query`  | Return the entity type, or use `count…`/`exists…` derived methods |
+| Non-suspend (including `Flow`) query methods | Declare `suspend fun … : List<T>`            |
+| Overloads with the same name and arity    | Give the methods distinct names                 |
+| `Top`/`First` combined with `Pageable`    | Use one or the other                            |
+| Sorting a native `@Query`                 | Put `ORDER BY` inside the query                 |
+
+---
+
+## Behavior Notes
+
+Differences worth knowing before you migrate, beyond the feature table above.
+
+**Deletes load before removing.** `deleteById`, `delete`, `deleteAll`, `deleteAllById` and derived
+`deleteBy…` methods fetch the target entities and remove them one by one, matching
+`SimpleJpaRepository`. Cascades, `@Version` checks and `@PreRemove` callbacks all fire, and the
+persistence context stays consistent. The cost is a `SELECT` before the `DELETE`; for bulk deletion
+without cascade semantics, write an explicit `@Modifying @Query("DELETE …")`.
+
+**Derived `deleteBy…` can return the deleted count.** Declare the method as `Unit`, `Int` or `Long`.
+
+**`LIKE` values are escaped.** `Containing`, `StartingWith` and `EndingWith` escape `%`, `_` and `\`
+in the bound value, so `findByNameContaining("%")` matches a literal percent sign rather than every
+row. The explicit `Like` keyword does not escape — there you supply the pattern yourself.
+
+**`IgnoreCase` compares both sides in lower case.** `IgnoreCase` on a non-String property is rejected
+at startup; `AllIgnoreCase` applies only to String properties.
+
+**`Sort` applies to `@Query` methods.** A `Sort` parameter or a sorted `Pageable` is appended to the
+query's own `ORDER BY` clause, so an ordering written into the query keeps priority.
+
+**Entity names come from the JPA metamodel.** `@Entity(name = "…")` and same-simple-name entities in
+different packages work correctly.
+
+**`Flow` is not streaming.** `findAll()` and other `Flow`-returning methods load the full result set
+before emitting. Use `Pageable` for large tables.
+
+**Mixing `@Transactional` and `tx.transactional {}` is safe.** `tx.transactional {}` joins an active
+Spring transaction instead of opening a second session, and refuses to upgrade a
+`@Transactional(readOnly = true)` transaction to a writable one.
 
 ---
 

--- a/hibernate-reactive-coroutines-core/api/hibernate-reactive-coroutines-core.api
+++ b/hibernate-reactive-coroutines-core/api/hibernate-reactive-coroutines-core.api
@@ -1,3 +1,14 @@
+public final class io/clroot/hibernate/reactive/AmbientTransaction {
+	public synthetic fun <init> (ZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getRemainingTimeout-UwyO8pc ()J
+	public final fun isReadOnly ()Z
+}
+
+public abstract interface class io/clroot/hibernate/reactive/AmbientTransactionProbe {
+	public abstract fun currentTransaction (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/clroot/hibernate/reactive/ReactiveSessionContext : kotlin/coroutines/AbstractCoroutineContextElement {
 	public static final field Key Lio/clroot/hibernate/reactive/ReactiveSessionContext$Key;
 	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$Session;Lio/clroot/hibernate/reactive/TransactionMode;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -27,6 +38,8 @@ public final class io/clroot/hibernate/reactive/ReactiveSessionProvider {
 public final class io/clroot/hibernate/reactive/ReactiveTransactionExecutor {
 	public static final field Companion Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor$Companion;
 	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;Lio/clroot/hibernate/reactive/AmbientTransactionProbe;)V
+	public synthetic fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;Lio/clroot/hibernate/reactive/AmbientTransactionProbe;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun readOnly-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun readOnly-KLykuaI$default (Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun transactional-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/AmbientTransactionProbe.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/AmbientTransactionProbe.kt
@@ -1,0 +1,30 @@
+package io.clroot.hibernate.reactive
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.INFINITE
+
+/**
+ * [ReactiveTransactionExecutor] 바깥에서 시작된 트랜잭션 정보.
+ *
+ * @param isReadOnly 읽기 전용 트랜잭션 여부
+ * @param remainingTimeout 남은 타임아웃 (제한이 없으면 [INFINITE])
+ */
+public class AmbientTransaction(
+    public val isReadOnly: Boolean,
+    public val remainingTimeout: Duration = INFINITE,
+)
+
+/**
+ * 현재 실행 컨텍스트에 이미 활성 트랜잭션이 있는지 확인하는 훅.
+ *
+ * 코어 모듈은 Spring에 의존하지 않으므로, Spring `@Transactional`이 시작한 트랜잭션은
+ * 스타터가 제공하는 구현을 통해 감지합니다. 이 훅이 없으면 `@Transactional` 안에서
+ * `tx.transactional {}`을 호출할 때 쓰이지 않는 세션과 트랜잭션이 하나 더 열립니다.
+ */
+public fun interface AmbientTransactionProbe {
+
+    /**
+     * 활성 트랜잭션이 있으면 그 정보를, 없으면 null을 반환합니다.
+     */
+    public suspend fun currentTransaction(): AmbientTransaction?
+}

--- a/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
+++ b/hibernate-reactive-coroutines-core/src/main/kotlin/io/clroot/hibernate/reactive/ReactiveTransactionExecutor.kt
@@ -41,8 +41,9 @@ import kotlin.time.Duration.Companion.seconds
  * - 트랜잭션 내에서 외부 I/O(HTTP 호출 등)를 수행하면 DB 커넥션이 오래 점유됨
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-public class ReactiveTransactionExecutor(
+public class ReactiveTransactionExecutor @JvmOverloads constructor(
     private val sessionFactory: Mutiny.SessionFactory,
+    private val ambientTransactionProbe: AmbientTransactionProbe? = null,
 ) {
     public companion object {
         public val DEFAULT_TIMEOUT: Duration = 30.seconds
@@ -119,11 +120,25 @@ public class ReactiveTransactionExecutor(
             )
         }
 
-        val effectiveTimeout = calculateEffectiveTimeout(parentContext, timeout)
+        // Spring @Transactional 등 바깥에서 시작된 트랜잭션은 코루틴 컨텍스트에 보이지 않는다.
+        // 감지하지 못하면 실제로는 쓰이지 않는 세션과 트랜잭션을 하나 더 열게 된다.
+        val ambientTransaction = if (parentContext == null) {
+            ambientTransactionProbe?.currentTransaction()
+        } else {
+            null
+        }
+        if (mode == TransactionMode.READ_WRITE && ambientTransaction?.isReadOnly == true) {
+            throw ReadOnlyTransactionException(
+                "Cannot start a write transaction within a read-only transaction. " +
+                        "Remove readOnly = true from the surrounding @Transactional annotation.",
+            )
+        }
+
+        val effectiveTimeout = calculateEffectiveTimeout(parentContext, ambientTransaction, timeout)
         val callerContext = currentCoroutineContext().minusKey(Job)
 
-        return if (parentContext != null) {
-            // 기존 세션 재사용 (REQUIRED 동작)
+        return if (parentContext != null || ambientTransaction != null) {
+            // 기존 트랜잭션에 참여 (REQUIRED 동작)
             executeWithTimeout(effectiveTimeout) { block() }
         } else {
             // 새 세션 생성 - Vert.x EventLoop에서 실행
@@ -161,11 +176,13 @@ public class ReactiveTransactionExecutor(
 
     private fun calculateEffectiveTimeout(
         parentContext: ReactiveSessionContext?,
+        ambientTransaction: AmbientTransaction?,
         timeout: Duration,
     ): Duration {
-        if (parentContext == null) return timeout
+        val remaining = parentContext?.remainingTimeout()
+            ?: ambientTransaction?.remainingTimeout
+            ?: return timeout
 
-        val remaining = parentContext.remainingTimeout()
         return when {
             remaining == INFINITE -> timeout
             timeout == INFINITE -> remaining

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/api/hibernate-reactive-coroutines-spring-boot-starter-boot4.api
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/api/hibernate-reactive-coroutines-spring-boot-starter-boot4.api
@@ -22,11 +22,12 @@ public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAuto
 
 public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration {
 	public fun <init> (Lorg/springframework/context/ApplicationContext;Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/lang/Integer;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZ)V
+	public fun ambientTransactionProbe (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/AmbientTransactionProbe;
 	public fun hibernateReactiveTransactionManager (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager;
 	public fun hibernateSessionFactory ()Lorg/hibernate/SessionFactory;
 	public fun reactiveSessionFactory (Lorg/hibernate/SessionFactory;)Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;
 	public fun reactiveSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveSessionProvider;
-	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;Lio/clroot/hibernate/reactive/AmbientTransactionProbe;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
 	public fun transactionalAwareSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
 	public fun transactionalEventPublisher (Lorg/springframework/context/ApplicationEventPublisher;)Lorg/springframework/transaction/reactive/TransactionalEventPublisher;
 }
@@ -110,8 +111,8 @@ public final class io/clroot/hibernate/reactive/spring/boot/repository/Hibernate
 
 public final class io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository : java/lang/reflect/InvocationHandler {
 	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository$Companion;
-	public fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;)V
-	public synthetic fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun invoke (Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -177,11 +178,12 @@ public final class io/clroot/hibernate/reactive/spring/boot/repository/query/Par
 }
 
 public final class io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod {
-	public fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/reflect/Method;
 	public final fun component10 ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
 	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/Integer;
 	public final fun component2 ()Lorg/springframework/data/repository/query/parser/PartTree;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -190,11 +192,12 @@ public final class io/clroot/hibernate/reactive/spring/boot/repository/query/Pre
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
-	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public final fun copy (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCountHql ()Ljava/lang/String;
 	public final fun getHql ()Ljava/lang/String;
+	public final fun getMaxResults ()Ljava/lang/Integer;
 	public final fun getMethod ()Ljava/lang/reflect/Method;
 	public final fun getParameterBinders ()Ljava/util/List;
 	public final fun getParameterNames ()Ljava/util/List;
@@ -247,6 +250,11 @@ public final class io/clroot/hibernate/reactive/spring/boot/transaction/MutinySe
 	public final fun setTransactionActive (Z)V
 	public final fun setVertxContext (Lio/vertx/core/Context;)V
 	public final fun toReactiveSessionContext ()Lio/clroot/hibernate/reactive/ReactiveSessionContext;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/transaction/SpringAmbientTransactionProbe : io/clroot/hibernate/reactive/AmbientTransactionProbe {
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public fun currentTransaction (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider {

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/build.gradle.kts
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/build.gradle.kts
@@ -38,10 +38,6 @@ dependencies {
     // Mutiny-Reactor (for Uni/Mono conversion)
     implementation(libs.mutiny.reactor)
 
-    // Spring Boot annotation processor
-    annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:4.0.0"))
-    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(libs.kotest.runner.junit5)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveTransactionManagementAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveTransactionManagementAutoConfiguration.kt
@@ -3,6 +3,8 @@ package io.clroot.hibernate.reactive.spring.boot.autoconfigure
 import org.hibernate.reactive.mutiny.Mutiny
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.transaction.annotation.AbstractTransactionManagementConfiguration
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 /**
@@ -10,8 +12,12 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
  *
  * Spring Boot 3 provides the equivalent infrastructure through its own
  * transaction auto-configuration.
+ *
+ * Backs off when the application already declares `@EnableTransactionManagement`, so that a
+ * user-chosen `proxyTargetClass` or `mode` is not silently competing with this declaration.
  */
 @AutoConfiguration(after = [HibernateReactiveAutoConfiguration::class])
 @ConditionalOnClass(Mutiny.SessionFactory::class)
+@ConditionalOnMissingBean(AbstractTransactionManagementConfiguration::class)
 @EnableTransactionManagement
 internal class HibernateReactiveTransactionManagementAutoConfiguration

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadataTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadataTest.kt
@@ -1,0 +1,79 @@
+package io.clroot.hibernate.reactive.spring.boot.auditing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+
+/**
+ * auditing 타임스탬프 처리를 검증합니다.
+ */
+class AuditMetadataTest : DescribeSpec({
+
+    describe("지원 시간 타입") {
+
+        it("OffsetDateTime 필드를 채운다") {
+            val entity = OffsetDateTimeEntity()
+
+            AuditMetadata.setCreatedDate(entity)
+            AuditMetadata.setLastModifiedDate(entity)
+
+            entity.createdAt.shouldNotBeNull()
+            entity.updatedAt.shouldNotBeNull()
+        }
+
+        it("ZonedDateTime 필드를 채운다") {
+            val entity = ZonedDateTimeEntity()
+
+            AuditMetadata.setCreatedDate(entity)
+
+            entity.createdAt.shouldNotBeNull()
+        }
+    }
+
+    describe("생성 시각") {
+
+        it("같은 기준 시각을 넘기면 생성/수정 시각이 동일하다") {
+            val entity = OffsetDateTimeEntity()
+            val now = Instant.now()
+
+            AuditMetadata.setCreatedDate(entity, now)
+            AuditMetadata.setLastModifiedDate(entity, now)
+
+            entity.createdAt!!.toInstant() shouldBe entity.updatedAt!!.toInstant()
+        }
+    }
+
+    describe("지원하지 않는 타입") {
+
+        it("필드를 건드리지 않는다") {
+            val entity = UnsupportedTypeEntity()
+
+            AuditMetadata.setCreatedDate(entity)
+
+            entity.createdAt shouldBe null
+        }
+    }
+})
+
+private class OffsetDateTimeEntity {
+    @CreatedDate
+    var createdAt: OffsetDateTime? = null
+
+    @LastModifiedDate
+    var updatedAt: OffsetDateTime? = null
+}
+
+private class ZonedDateTimeEntity {
+    @CreatedDate
+    var createdAt: ZonedDateTime? = null
+}
+
+private class UnsupportedTypeEntity {
+    @CreatedDate
+    var createdAt: StringBuilder? = null
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveTransactionManagerAutoConfigurationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveTransactionManagerAutoConfigurationTest.kt
@@ -1,0 +1,82 @@
+package io.clroot.hibernate.reactive.spring.boot.autoconfigure
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.mockk
+import org.hibernate.SessionFactory
+import org.hibernate.reactive.mutiny.Mutiny
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.transaction.ReactiveTransactionManager
+
+class HibernateReactiveTransactionManagerAutoConfigurationTest : DescribeSpec({
+    describe("Hibernate Reactive transaction manager auto-configuration") {
+        it("backs off when another ReactiveTransactionManager exists") {
+            contextRunner()
+                .withBean(
+                    "r2dbcTransactionManager",
+                    ReactiveTransactionManager::class.java,
+                    { mockk<ReactiveTransactionManager>() },
+                )
+                .run { context ->
+                    context.getBeanNamesForType(ReactiveTransactionManager::class.java).toList() shouldContainExactly
+                            listOf("r2dbcTransactionManager")
+                }
+        }
+
+        it("registers its own transaction manager when none exists") {
+            contextRunner().run { context ->
+                context.getBeanNamesForType(ReactiveTransactionManager::class.java).toList() shouldContainExactly
+                        listOf("hibernateReactiveTransactionManager")
+            }
+        }
+    }
+
+    describe("session factory auto-configuration") {
+        it("does not build a second session factory when the user supplies a Mutiny.SessionFactory") {
+            ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+                .withBean("userSessionFactory", Mutiny.SessionFactory::class.java, { mockk<Mutiny.SessionFactory>() })
+                .run { context ->
+                    context.getBeanNamesForType(Mutiny.SessionFactory::class.java).toList() shouldContainExactly
+                            listOf("userSessionFactory")
+                    context.containsBean("hibernateSessionFactory") shouldBe false
+                }
+        }
+
+        it("starts without spring.datasource.url when the user supplies a Mutiny.SessionFactory") {
+            ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+                .withBean("userSessionFactory", Mutiny.SessionFactory::class.java, { mockk<Mutiny.SessionFactory>() })
+                .run { context ->
+                    context.startupFailure shouldBe null
+                }
+        }
+
+        it("fails with an actionable message when spring.datasource.url is missing") {
+            // Testcontainers 픽스처가 JVM 시스템 프로퍼티를 설정하므로 빈 값으로 덮어씁니다.
+            ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+                .withPropertyValues("spring.datasource.url=")
+                .run { context ->
+                    val failure = context.startupFailure.shouldNotBeNull()
+                    failure.stackTraceToString() shouldContain "spring.datasource.url"
+                }
+        }
+    }
+})
+
+private fun contextRunner(): ApplicationContextRunner =
+    ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+        .withBean("hibernateSessionFactory", SessionFactory::class.java, { mockk<SessionFactory>() })
+        .withBean("reactiveSessionFactory", Mutiny.SessionFactory::class.java, { mockk<Mutiny.SessionFactory>() })
+        .withPropertyValues(
+            "spring.datasource.url=jdbc:postgresql://localhost/test",
+            "spring.datasource.username=test",
+            "spring.datasource.password=test",
+            "spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect",
+        )

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBeanTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBeanTest.kt
@@ -6,13 +6,25 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
 import io.mockk.mockk
+import jakarta.persistence.metamodel.EntityType
+import jakarta.persistence.metamodel.Metamodel
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 
 class HibernateReactiveRepositoryFactoryBeanTest : DescribeSpec({
 
     val sessionProvider = mockk<TransactionalAwareSessionProvider>()
     val transactionExecutor = mockk<ReactiveTransactionExecutor>()
+
+    // HQL 엔티티 이름은 JPA 메타모델에서 조회하므로 테스트에서도 등록된 엔티티처럼 동작시킵니다.
+    val metamodel = mockk<Metamodel>()
+    every { sessionProvider.metamodel } returns metamodel
+    every { metamodel.entity(any<Class<*>>()) } answers {
+        mockk<EntityType<*>> {
+            every { name } returns firstArg<Class<*>>().simpleName
+        }
+    }
 
     describe("HibernateReactiveRepositoryFactoryBean") {
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
@@ -202,10 +202,10 @@ private interface QueryRepository {
     suspend fun findWithRolesAndCount(pageable: Pageable): Page<User>
 
     @Query(
-        value = "SELECT e.active FROM User e GROUP BY e.active",
+        value = "SELECT e FROM User e GROUP BY e",
         countQuery = "SELECT COUNT(DISTINCT e.active) FROM User e",
     )
-    suspend fun countByActiveWithCount(pageable: Pageable): Page<Boolean>
+    suspend fun countByActiveWithCount(pageable: Pageable): Page<User>
 
     @Query(
         value = "SELECT e FROM User e WHERE e.active = :active " +

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodValidationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodValidationTest.kt
@@ -1,0 +1,120 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.clroot.hibernate.reactive.spring.boot.repository.query.PartTreeHqlBuilder
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.springframework.data.repository.query.parser.PartTree
+
+/**
+ * 예전에는 시작 시점을 통과한 뒤 런타임에 조용히 오동작하던 선언들이
+ * 이제 명확한 메시지로 거부되는지 검증합니다.
+ */
+class QueryMethodValidationTest : DescribeSpec({
+    val parser = QueryMethodParser(Member::class.java)
+
+    fun parse(methodName: String) = parser.parse(
+        MemberRepository::class.java.methods.single { it.name == methodName },
+    )
+
+    describe("IgnoreCase") {
+        it("compares both sides in lower case") {
+            val partTree = PartTree("findByName", Member::class.java)
+            PartTreeHqlBuilder("Member", PartTree("findByNameIgnoreCase", Member::class.java))
+                .build()
+                .hql shouldBe "FROM Member e WHERE LOWER(e.name) = LOWER(:p0)"
+
+            // 대조군: IgnoreCase가 없으면 그대로 비교합니다.
+            PartTreeHqlBuilder("Member", partTree).build().hql shouldBe
+                    "FROM Member e WHERE e.name = :p0"
+        }
+
+        it("applies to LIKE conditions as well") {
+            PartTreeHqlBuilder("Member", PartTree("findByNameContainingIgnoreCase", Member::class.java))
+                .build()
+                .hql shouldBe "FROM Member e WHERE LOWER(e.name) LIKE LOWER(:p0) ESCAPE '\\'"
+        }
+
+        it("rejects IgnoreCase on a non-String property") {
+            val error = shouldThrow<IllegalStateException> {
+                PartTreeHqlBuilder("Member", PartTree("findByAgeIgnoreCase", Member::class.java)).build()
+            }
+
+            error.message shouldContain "non-String property"
+        }
+    }
+
+    describe("Distinct") {
+        it("emits SELECT DISTINCT") {
+            PartTreeHqlBuilder("Member", PartTree("findDistinctByName", Member::class.java))
+                .build()
+                .hql shouldBe "SELECT DISTINCT e FROM Member e WHERE e.name = :p0"
+        }
+    }
+
+    describe("Top/First limiting") {
+        it("captures the declared limit") {
+            parse("findTop3ByOrderByAgeDesc").maxResults shouldBe 3
+            parse("findFirstByOrderByAgeDesc").maxResults shouldBe 1
+            parse("findByName").maxResults shouldBe null
+        }
+
+        it("rejects combining a limit with Pageable") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findTop3ByName")
+            }
+
+            error.message shouldContain "ambiguous"
+        }
+    }
+
+    describe("derived query parameters") {
+        it("rejects a method whose name needs more arguments than it declares") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findByNameAndAge")
+            }
+
+            error.message shouldContain "derives 2 query parameter(s)"
+        }
+    }
+
+    describe("@Query result types") {
+        it("rejects scalar projections") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("sumAges")
+            }
+
+            error.message shouldContain "only the entity type Member"
+        }
+
+        it("accepts entity results") {
+            parse("findActive").hql shouldContain "FROM Member"
+        }
+    }
+})
+
+private class Member(
+    val id: Long,
+    val name: String,
+    val age: Int,
+)
+
+private interface MemberRepository {
+    suspend fun findByName(name: String): Member?
+
+    suspend fun findTop3ByOrderByAgeDesc(): List<Member>
+
+    suspend fun findFirstByOrderByAgeDesc(): Member?
+
+    suspend fun findTop3ByName(name: String, pageable: org.springframework.data.domain.Pageable): List<Member>
+
+    suspend fun findByNameAndAge(name: String): Member?
+
+    @Query("SELECT SUM(e.age) FROM Member e")
+    suspend fun sumAges(): Long
+
+    @Query("SELECT e FROM Member e WHERE e.age > 0")
+    suspend fun findActive(): List<Member>
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
@@ -214,6 +214,7 @@ class SimpleHibernateReactiveRepositoryTest : DescribeSpec({
 
                 val crud = CrudOperations<SaveAllEntity, Long>(
                     entityClass = SaveAllEntity::class.java,
+                    entityName = "SaveAllEntity",
                     sessionProvider = localSessionProvider,
                     transactionExecutor = localTransactionExecutor,
                     auditingHandler = null,

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PartTreeHqlBuilderTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PartTreeHqlBuilderTest.kt
@@ -83,7 +83,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders shouldHaveSize 1
                 result.parameterBinders[0] shouldBe ParameterBinder.Containing
             }
@@ -94,7 +94,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders shouldHaveSize 1
                 result.parameterBinders[0] shouldBe ParameterBinder.StartingWith
             }
@@ -105,7 +105,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders shouldHaveSize 1
                 result.parameterBinders[0] shouldBe ParameterBinder.EndingWith
             }
@@ -116,7 +116,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name NOT LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name NOT LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders[0] shouldBe ParameterBinder.Containing
             }
         }
@@ -335,7 +335,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "DELETE FROM User e WHERE e.name = :p0"
+                result.hql shouldBe "FROM User e WHERE e.name = :p0"
             }
 
             it("deleteByAge") {
@@ -344,7 +344,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "DELETE FROM User e WHERE e.age = :p0"
+                result.hql shouldBe "FROM User e WHERE e.age = :p0"
             }
         }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/AnnotatedQuerySortTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/AnnotatedQuerySortTest.kt
@@ -1,0 +1,80 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.TestEntity
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.kotest.matchers.collections.shouldContainExactly
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+/**
+ * `@Query` 메서드에도 동적 정렬이 적용되는지 검증합니다.
+ *
+ * 정렬이 무시되면 페이징 결과 순서가 보장되지 않아 페이지 간 중복·누락이 발생합니다.
+ */
+@SpringBootTest
+class AnnotatedQuerySortTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    init {
+        beforeEach {
+            tx.transactional {
+                testEntityRepository.save(TestEntity(name = "b", value = 10))
+                testEntityRepository.save(TestEntity(name = "a", value = 20))
+                testEntityRepository.save(TestEntity(name = "c", value = 30))
+            }
+        }
+
+        describe("@Query + Sort 파라미터") {
+
+            it("Sort를 적용한다") {
+                val sorted = tx.readOnly {
+                    testEntityRepository.findByValueGreaterThanWithQuery(0, Sort.by("name"))
+                }
+
+                sorted.map { it.name } shouldContainExactly listOf("a", "b", "c")
+            }
+
+            it("쿼리에 이미 있는 ORDER BY를 보존하고 뒤에 덧붙인다") {
+                val sorted = tx.readOnly {
+                    testEntityRepository.findOrderedByValueGreaterThanWithQuery(0, Sort.by("name"))
+                }
+
+                // 쿼리의 value DESC가 우선 적용됩니다.
+                sorted.map { it.name } shouldContainExactly listOf("c", "a", "b")
+            }
+        }
+
+        describe("@Query + 정렬된 Pageable") {
+
+            it("Page 조회에 Pageable의 Sort를 적용한다") {
+                val page = tx.readOnly {
+                    testEntityRepository.findByValueWithQueryPageable(
+                        10,
+                        PageRequest.of(0, 10, Sort.by("name")),
+                    )
+                }
+
+                page.content.map { it.name } shouldContainExactly listOf("b")
+            }
+
+            it("Slice 조회에 Pageable의 Sort를 적용한다") {
+                val slice = tx.readOnly {
+                    testEntityRepository.findByValueGreaterThanWithQuerySlice(
+                        0,
+                        PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "name")),
+                    )
+                }
+
+                slice.content.map { it.name } shouldContainExactly listOf("c", "b")
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/DeleteSemanticsAndLimitTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/DeleteSemanticsAndLimitTest.kt
@@ -1,0 +1,142 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.ChildEntity
+import io.clroot.hibernate.reactive.test.entity.ParentEntity
+import io.clroot.hibernate.reactive.test.entity.TestEntity
+import io.clroot.hibernate.reactive.test.repository.ChildEntityRepository
+import io.clroot.hibernate.reactive.test.repository.ParentEntityRepository
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * 삭제 의미론과 결과 개수 제한 동작을 검증합니다.
+ *
+ * bulk `DELETE` 문은 cascade와 영속성 컨텍스트를 건너뛰므로, 로드 후 제거 방식으로
+ * 동작하는지 실제 DB에 대해 확인합니다.
+ */
+@SpringBootTest
+class DeleteSemanticsAndLimitTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    @Autowired
+    private lateinit var parentEntityRepository: ParentEntityRepository
+
+    @Autowired
+    private lateinit var childEntityRepository: ChildEntityRepository
+
+    init {
+        describe("deleteById") {
+
+            it("자식까지 cascade 삭제한다") {
+                val parentId = tx.transactional {
+                    val parent = ParentEntity(name = "parent")
+                    parent.addChild(ChildEntity(name = "child-1"))
+                    parent.addChild(ChildEntity(name = "child-2"))
+                    parentEntityRepository.save(parent).id!!
+                }
+
+                tx.transactional {
+                    parentEntityRepository.deleteById(parentId)
+                }
+
+                tx.readOnly {
+                    parentEntityRepository.findById(parentId) shouldBe null
+                }
+                countChildRows() shouldBe 0L
+            }
+
+            it("존재하지 않는 ID는 조용히 무시한다") {
+                tx.transactional {
+                    testEntityRepository.deleteById(-1L)
+                }
+            }
+
+            it("같은 트랜잭션 안에서 삭제한 엔티티는 다시 조회되지 않는다") {
+                val id = tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "gone", value = 1)).id!!
+                }
+
+                tx.transactional {
+                    testEntityRepository.deleteById(id)
+                    testEntityRepository.findById(id) shouldBe null
+                }
+            }
+        }
+
+        describe("deleteAll") {
+
+            it("자식까지 cascade 삭제한다") {
+                tx.transactional {
+                    val parent = ParentEntity(name = "parent")
+                    parent.addChild(ChildEntity(name = "child-1"))
+                    parentEntityRepository.save(parent)
+                }
+
+                tx.transactional {
+                    parentEntityRepository.deleteAll()
+                }
+
+                tx.readOnly {
+                    parentEntityRepository.count() shouldBe 0L
+                }
+                countChildRows() shouldBe 0L
+            }
+        }
+
+        describe("파생 deleteBy 메서드") {
+
+            it("삭제 건수를 반환한다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "a", value = 7))
+                    testEntityRepository.save(TestEntity(name = "b", value = 7))
+                    testEntityRepository.save(TestEntity(name = "c", value = 8))
+                }
+
+                val deleted = tx.transactional {
+                    testEntityRepository.deleteAllByValue(7)
+                }
+
+                deleted shouldBe 2L
+                tx.readOnly { testEntityRepository.count() } shouldBe 1L
+            }
+        }
+
+        describe("Top/First 개수 제한") {
+
+            it("findTop2By는 상위 2건만 반환한다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "low", value = 1))
+                    testEntityRepository.save(TestEntity(name = "mid", value = 5))
+                    testEntityRepository.save(TestEntity(name = "high", value = 9))
+                }
+
+                val top = tx.readOnly { testEntityRepository.findTop2ByOrderByValueDesc() }
+
+                top.map { it.name } shouldContainExactly listOf("high", "mid")
+            }
+
+            it("findFirstBy는 여러 건이 매칭돼도 예외 없이 첫 건을 반환한다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "low", value = 1))
+                    testEntityRepository.save(TestEntity(name = "high", value = 9))
+                }
+
+                val first = tx.readOnly { testEntityRepository.findFirstByOrderByValueDesc() }
+
+                first.shouldNotBeNull().name shouldBe "high"
+            }
+        }
+    }
+
+    private suspend fun countChildRows(): Long = tx.readOnly { childEntityRepository.count() }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/EntityNamingAndLikeEscapingTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/EntityNamingAndLikeEscapingTest.kt
@@ -1,0 +1,85 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.RenamedEntity
+import io.clroot.hibernate.reactive.test.entity.TestEntity
+import io.clroot.hibernate.reactive.test.repository.RenamedEntityRepository
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * 엔티티 이름 해석과 LIKE 와일드카드 이스케이프를 실제 DB에 대해 검증합니다.
+ */
+@SpringBootTest
+class EntityNamingAndLikeEscapingTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var renamedEntityRepository: RenamedEntityRepository
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    init {
+        describe("@Entity(name = ...)로 이름을 바꾼 엔티티") {
+
+            it("기본 CRUD가 동작한다") {
+                val saved = tx.transactional {
+                    renamedEntityRepository.save(RenamedEntity(name = "renamed"))
+                }
+
+                tx.readOnly {
+                    renamedEntityRepository.findById(saved.id!!).shouldNotBeNull().name shouldBe "renamed"
+                    renamedEntityRepository.count() shouldBe 1L
+                }
+            }
+
+            it("파생 쿼리가 동작한다") {
+                tx.transactional {
+                    renamedEntityRepository.save(RenamedEntity(name = "target"))
+                    renamedEntityRepository.save(RenamedEntity(name = "other"))
+                }
+
+                tx.readOnly {
+                    renamedEntityRepository.findByName("target").shouldNotBeNull()
+                }
+
+                val deleted = tx.transactional { renamedEntityRepository.deleteByName("target") }
+
+                deleted shouldBe 1L
+                tx.readOnly { renamedEntityRepository.count() } shouldBe 1L
+            }
+        }
+
+        describe("LIKE 와일드카드 이스케이프") {
+
+            it("Containing에 %를 넘겨도 전체 행이 매칭되지 않는다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "plain", value = 1))
+                    testEntityRepository.save(TestEntity(name = "100% cotton", value = 2))
+                }
+
+                val matched = tx.readOnly { testEntityRepository.findAllByNameContaining("%") }
+
+                matched.map { it.name } shouldContainExactlyInAnyOrder listOf("100% cotton")
+            }
+
+            it("Containing의 _는 임의의 한 글자가 아니라 밑줄 자체로 매칭된다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "a_b", value = 1))
+                    testEntityRepository.save(TestEntity(name = "axb", value = 2))
+                }
+
+                val matched = tx.readOnly { testEntityRepository.findAllByNameContaining("a_b") }
+
+                matched.map { it.name } shouldContainExactlyInAnyOrder listOf("a_b")
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/HqlRecorderTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/HqlRecorderTest.kt
@@ -98,7 +98,7 @@ class HqlRecorderTest : RecordingIntegrationTestBase() {
 
             context("DELETE 쿼리 기록") {
 
-                it("deleteByName은 DELETE HQL을 생성한다") {
+                it("deleteByName은 대상을 조회한 뒤 제거한다") {
                     // given
                     tx.transactional {
                         testEntityRepository.save(TestEntity(name = "to-delete", value = 1))
@@ -111,9 +111,10 @@ class HqlRecorderTest : RecordingIntegrationTestBase() {
                     }
 
                     // then
+                    // cascade와 @Version이 동작하도록 bulk DELETE 대신 로드 후 제거합니다.
                     hqlRecorder.assertQueryCount(1)
-                    hqlRecorder.assertLastQueryContains("DELETE FROM TestEntity")
-                    hqlRecorder.getLastQuery()?.queryType shouldBe QueryType.DELETE
+                    hqlRecorder.assertLastQueryContains("FROM TestEntity")
+                    hqlRecorder.getLastQuery()?.queryType shouldBe QueryType.SELECT
                 }
             }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/MixedTransactionModelTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/test/kotlin/io/clroot/hibernate/reactive/test/MixedTransactionModelTest.kt
@@ -1,0 +1,56 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.ReadOnlyTransactionException
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.clroot.hibernate.reactive.test.service.TransactionalTestService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+
+/**
+ * Spring `@Transactional`과 `tx.transactional {}`을 함께 쓸 때의 동작을 검증합니다.
+ *
+ * `tx.transactional`이 바깥 Spring 트랜잭션을 감지하지 못하면 별도 세션과 트랜잭션이 열려
+ * 롤백 경계가 어긋납니다.
+ */
+@SpringBootTest(classes = [TestApplication::class, TransactionalTestService::class])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+class MixedTransactionModelTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var testService: TransactionalTestService
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    init {
+        describe("@Transactional 안의 tx.transactional") {
+
+            it("중복 세션을 열지 않는다") {
+                testService.opensRedundantSession() shouldBe false
+            }
+
+            it("바깥 트랜잭션에 참여하여 함께 롤백된다") {
+                shouldThrow<RuntimeException> {
+                    testService.saveNestedAndFail("nested-rollback", 1)
+                }
+
+                tx.readOnly { testEntityRepository.count() } shouldBe 0L
+            }
+
+            it("읽기 전용 트랜잭션을 쓰기로 승격하지 못한다") {
+                shouldThrow<ReadOnlyTransactionException> {
+                    testService.upgradeReadOnlyTransaction("should-not-persist")
+                }
+
+                tx.readOnly { testEntityRepository.count() } shouldBe 0L
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/IntegrationTestBase.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/IntegrationTestBase.kt
@@ -3,6 +3,7 @@ package io.clroot.hibernate.reactive.test
 import io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveAutoConfiguration
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
+import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny
 import org.springframework.beans.factory.annotation.Autowired
@@ -57,17 +58,29 @@ abstract class IntegrationTestBase : DescribeSpec() {
     /**
      * 모든 테스트 테이블의 데이터를 삭제합니다.
      * 스키마 격리 환경에서 안전하게 동작하도록 DELETE를 사용합니다.
+     * FK 제약조건 순서를 고려하여 자식 테이블부터 삭제합니다.
      */
     private suspend fun clearAllTables() {
+        // FK 제약조건 순서: 자식 → 부모
+        val entityNames = listOf(
+            "ChildEntity",
+            "ParentEntity",
+            "VersionedEntity",
+            "AnotherEntity",
+            "RenamedAlias",
+            "TestEntity",
+        )
+
         sessionFactory.withTransaction { session ->
-            // 스키마 격리 환경에서는 DELETE가 더 안전함
-            // (currentSchema 설정이 search_path에 영향을 주지 않을 수 있음)
-            // FK 제약으로 인해 자식 테이블 먼저 삭제
-            session.createMutationQuery("DELETE FROM ChildEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM ParentEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM VersionedEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM AnotherEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM TestEntity").executeUpdate()
+            // Uni는 구독해야 실행되므로 반드시 chain으로 연결한다.
+            // 나열만 하면 마지막 구문 외에는 실행되지 않는다.
+            entityNames.fold(Uni.createFrom().voidItem()) { chain, entityName ->
+                chain.chain { _ ->
+                    session.createMutationQuery("DELETE FROM $entityName")
+                        .executeUpdate()
+                        .replaceWithVoid()
+                }
+            }
         }.awaitSuspending()
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/RenamedEntity.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/RenamedEntity.kt
@@ -1,0 +1,24 @@
+package io.clroot.hibernate.reactive.test.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+/**
+ * HQL 엔티티 이름이 클래스 단순 이름과 다른 엔티티.
+ *
+ * 엔티티 이름을 클래스 이름에서 유추하면 이 엔티티를 대상으로 한 모든 쿼리가 실패합니다.
+ */
+@Entity(name = "RenamedAlias")
+@Table(name = "renamed_entity")
+class RenamedEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    var name: String = "",
+)

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ChildEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ChildEntityRepository.kt
@@ -1,0 +1,9 @@
+package io.clroot.hibernate.reactive.test.repository
+
+import io.clroot.hibernate.reactive.test.entity.ChildEntity
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+/**
+ * cascade 삭제 검증용 Repository.
+ */
+interface ChildEntityRepository : CoroutineCrudRepository<ChildEntity, Long>

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/RenamedEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/RenamedEntityRepository.kt
@@ -1,0 +1,14 @@
+package io.clroot.hibernate.reactive.test.repository
+
+import io.clroot.hibernate.reactive.test.entity.RenamedEntity
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+/**
+ * `@Entity(name = ...)`로 이름을 바꾼 엔티티용 Repository.
+ */
+interface RenamedEntityRepository : CoroutineCrudRepository<RenamedEntity, Long> {
+
+    suspend fun findByName(name: String): RenamedEntity?
+
+    suspend fun deleteByName(name: String): Long
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
@@ -32,6 +32,14 @@ interface TestEntityRepository : CoroutineCrudRepository<TestEntity, Long> {
     // 삭제
     suspend fun deleteByName(name: String)
 
+    // 삭제 건수 반환
+    suspend fun deleteAllByValue(value: Int): Long
+
+    // 개수 제한 (Top/First)
+    suspend fun findTop2ByOrderByValueDesc(): List<TestEntity>
+
+    suspend fun findFirstByOrderByValueDesc(): TestEntity?
+
     // LIKE 검색 (Containing)
     suspend fun findAllByNameContaining(name: String): List<TestEntity>
 
@@ -105,4 +113,18 @@ interface TestEntityRepository : CoroutineCrudRepository<TestEntity, Long> {
         countQuery = "SELECT COUNT(e) FROM TestEntity e WHERE e.value = :value",
     )
     suspend fun findByValueWithExplicitCount(@Param("value") value: Int, pageable: Pageable): Page<TestEntity>
+
+    // @Query + 동적 Sort
+    @Query("SELECT e FROM TestEntity e WHERE e.value > :minValue")
+    suspend fun findByValueGreaterThanWithQuery(
+        @Param("minValue") minValue: Int,
+        sort: Sort,
+    ): List<TestEntity>
+
+    // @Query에 ORDER BY가 이미 있는 경우
+    @Query("SELECT e FROM TestEntity e WHERE e.value > :minValue ORDER BY e.value DESC")
+    suspend fun findOrderedByValueGreaterThanWithQuery(
+        @Param("minValue") minValue: Int,
+        sort: Sort,
+    ): List<TestEntity>
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/TransactionalTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-boot4/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/TransactionalTestService.kt
@@ -1,5 +1,8 @@
 package io.clroot.hibernate.reactive.test.service
 
+import io.clroot.hibernate.reactive.ReactiveSessionContext
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.currentSessionOrNull
 import io.clroot.hibernate.reactive.test.entity.TestEntity
 import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
 import org.springframework.stereotype.Service
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class TransactionalTestService(
     private val testEntityRepository: TestEntityRepository,
+    private val transactionExecutor: ReactiveTransactionExecutor,
 ) {
     @Transactional
     suspend fun saveEntity(name: String, value: Int): TestEntity {
@@ -59,5 +63,41 @@ class TransactionalTestService(
         }
         onSaved(savedEntities.map { it.id!! })
         throw RuntimeException("의도적 롤백 - 모든 저장이 롤백되어야 함")
+    }
+
+    // === @Transactional 안에서 tx.transactional {} 을 함께 쓰는 경우 ===
+
+    /**
+     * `tx.transactional {}`이 바깥 `@Transactional`에 참여해야 합니다.
+     * 별도 트랜잭션이 열리면 이 저장은 롤백되지 않습니다.
+     */
+    @Transactional
+    suspend fun saveNestedAndFail(name: String, value: Int) {
+        transactionExecutor.transactional {
+            testEntityRepository.save(TestEntity(name = name, value = value))
+        }
+        throw RuntimeException("의도적 롤백 - 중첩 저장까지 롤백되어야 함")
+    }
+
+    /**
+     * `tx.transactional {}`이 바깥 Spring 트랜잭션을 감지했는지 확인합니다.
+     *
+     * 감지하지 못하면 새 세션을 열면서 [ReactiveSessionContext]를 코루틴 컨텍스트에 추가합니다.
+     * 즉 여기서 세션이 보인다면 쓰이지도 않을 세션이 하나 더 열렸다는 뜻입니다.
+     */
+    @Transactional
+    suspend fun opensRedundantSession(): Boolean =
+        transactionExecutor.transactional {
+            currentSessionOrNull() != null
+        }
+
+    /**
+     * 읽기 전용 `@Transactional` 안에서는 쓰기 트랜잭션으로 승격할 수 없습니다.
+     */
+    @Transactional(readOnly = true)
+    suspend fun upgradeReadOnlyTransaction(name: String) {
+        transactionExecutor.transactional {
+            testEntityRepository.save(TestEntity(name = name, value = 0))
+        }
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadata.kt
@@ -10,6 +10,8 @@ import org.springframework.data.annotation.LastModifiedDate
 import java.lang.reflect.Field
 import java.time.Instant
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
@@ -36,26 +38,31 @@ internal object AuditMetadata {
 
     /**
      * @CreatedDate 필드에 현재 시간을 설정합니다.
+     *
+     * @param now 기준 시각. 생략하면 현재 시각을 사용합니다.
      */
-    fun setCreatedDate(entity: Any) {
+    fun setCreatedDate(entity: Any, now: Instant = Instant.now()) {
         val auditInfo = getAuditInfo(entity.javaClass)
         auditInfo.createdDateField?.let { field ->
             val currentValue = getFieldValueSafely(entity, field)
             val isUnsetPrimitiveLong =
                 field.type == Long::class.javaPrimitiveType && currentValue == 0L
             if (currentValue == null || isUnsetPrimitiveLong) {
-                setTemporalValue(entity, field)
+                setTemporalValue(entity, field, now)
             }
         }
     }
 
     /**
      * @LastModifiedDate 필드에 현재 시간을 설정합니다.
+     *
+     * @param now 기준 시각. 생성 시점에는 createdDate와 같은 값을 넘겨야
+     *   `createdAt == updatedAt`으로 "한 번도 수정되지 않음"을 판별할 수 있습니다.
      */
-    fun setLastModifiedDate(entity: Any) {
+    fun setLastModifiedDate(entity: Any, now: Instant = Instant.now()) {
         val auditInfo = getAuditInfo(entity.javaClass)
         auditInfo.lastModifiedDateField?.let { field ->
-            setTemporalValue(entity, field)
+            setTemporalValue(entity, field, now)
         }
     }
 
@@ -115,16 +122,19 @@ internal object AuditMetadata {
     }
 
     /**
-     * 필드 타입에 맞는 현재 시간 값을 설정합니다.
+     * 필드 타입에 맞는 시간 값을 설정합니다.
+     *
+     * @param now 기준 시각. 같은 저장에서 생성/수정 시각을 동일하게 맞추기 위해 호출자가 전달합니다.
      */
-    private fun setTemporalValue(entity: Any, field: Field) {
+    private fun setTemporalValue(entity: Any, field: Field, now: Instant) {
         val value: Any = when (field.type) {
-            Instant::class.java -> Instant.now()
-            LocalDateTime::class.java -> LocalDateTime.now()
-            ZonedDateTime::class.java -> ZonedDateTime.now()
-            Date::class.java -> Date()
-            Long::class.javaObjectType, Long::class.javaPrimitiveType -> System.currentTimeMillis()
-            else -> return // 지원하지 않는 타입
+            Instant::class.java -> now
+            LocalDateTime::class.java -> LocalDateTime.ofInstant(now, ZoneId.systemDefault())
+            OffsetDateTime::class.java -> OffsetDateTime.ofInstant(now, ZoneId.systemDefault())
+            ZonedDateTime::class.java -> ZonedDateTime.ofInstant(now, ZoneId.systemDefault())
+            Date::class.java -> Date.from(now)
+            Long::class.javaObjectType, Long::class.javaPrimitiveType -> now.toEpochMilli()
+            else -> return // isSupportedTemporalType이 걸러내므로 도달하지 않음
         }
         setFieldValueSafely(entity, field, value)
     }
@@ -160,12 +170,16 @@ internal object AuditMetadata {
                     field.isAnnotationPresent(CreatedDate::class.java) && createdDateField == null -> {
                         if (isSupportedTemporalType(field.type)) {
                             createdDateField = field
+                        } else {
+                            warnUnsupportedTemporalType(cls, field, "@CreatedDate")
                         }
                     }
 
                     field.isAnnotationPresent(LastModifiedDate::class.java) && lastModifiedDateField == null -> {
                         if (isSupportedTemporalType(field.type)) {
                             lastModifiedDateField = field
+                        } else {
+                            warnUnsupportedTemporalType(cls, field, "@LastModifiedDate")
                         }
                     }
 
@@ -198,10 +212,13 @@ internal object AuditMetadata {
      */
     private fun tryMakeAccessible(field: Field): Boolean {
         return try {
-            field.isAccessible = true
-            true
+            // 모듈 경로에서 열리지 않은 패키지는 InaccessibleObjectException을 던진다.
+            field.trySetAccessible()
         } catch (e: SecurityException) {
             logger.debug("Cannot make field '${field.name}' accessible due to security restrictions", e)
+            false
+        } catch (e: RuntimeException) {
+            logger.debug("Cannot make field '${field.name}' accessible", e)
             false
         }
     }
@@ -212,9 +229,27 @@ internal object AuditMetadata {
     private fun isSupportedTemporalType(type: Class<*>): Boolean {
         return type == Instant::class.java ||
                 type == LocalDateTime::class.java ||
+                type == OffsetDateTime::class.java ||
                 type == ZonedDateTime::class.java ||
                 type == Date::class.java ||
                 type == Long::class.javaObjectType ||
                 type == Long::class.javaPrimitiveType
+    }
+
+    /**
+     * 지원하지 않는 타입에 auditing 어노테이션이 붙으면 조용히 넘어가지 않고 경고합니다.
+     *
+     * 경고가 없으면 필드가 계속 null로 남아 NOT NULL 제약 위반으로만 문제가 드러납니다.
+     */
+    private fun warnUnsupportedTemporalType(cls: Class<*>, field: Field, annotation: String) {
+        logger.warn(
+            "{}.{} is annotated with {} but its type {} is not supported; " +
+                    "the field will not be populated. Supported types: " +
+                    "Instant, LocalDateTime, OffsetDateTime, ZonedDateTime, java.util.Date, Long.",
+            cls.name,
+            field.name,
+            annotation,
+            field.type.name,
+        )
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditingEntityListener.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditingEntityListener.kt
@@ -2,6 +2,7 @@ package io.clroot.hibernate.reactive.spring.boot.auditing
 
 import jakarta.persistence.PrePersist
 import jakarta.persistence.PreUpdate
+import java.time.Instant
 
 /**
  * JPA 엔티티 라이프사이클 콜백을 통해 Auditing 타임스탬프를 자동으로 설정하는 리스너.
@@ -47,8 +48,11 @@ public class AuditingEntityListener {
      */
     @PrePersist
     public fun onPrePersist(entity: Any) {
-        AuditMetadata.setCreatedDate(entity)
-        AuditMetadata.setLastModifiedDate(entity)
+        // 두 필드가 같은 시각을 갖도록 한 번만 읽는다.
+        // 값이 미세하게 다르면 createdAt == updatedAt 으로 "수정된 적 없음"을 판별할 수 없다.
+        val now = Instant.now()
+        AuditMetadata.setCreatedDate(entity, now)
+        AuditMetadata.setLastModifiedDate(entity, now)
     }
 
     /**

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAutoConfiguration.kt
@@ -17,13 +17,17 @@ import org.springframework.context.annotation.Bean
  * ```kotlin
  * @Component
  * class SecurityAuditorAware : ReactiveAuditorAware<String> {
- *     override suspend fun getCurrentAuditor(): String? {
- *         return SecurityContextHolder.getContext()
+ *     override suspend fun getCurrentAuditor(): String? =
+ *         ReactiveSecurityContextHolder.getContext()
+ *             .awaitSingleOrNull()
  *             ?.authentication
  *             ?.name
- *     }
  * }
  * ```
+ *
+ * WebFlux에서는 `SecurityContextHolder`(ThreadLocal)가 채워지지 않으므로 반드시
+ * `ReactiveSecurityContextHolder`를 사용해야 합니다. ThreadLocal을 읽으면 감사자가
+ * 항상 null이 되어 `@CreatedBy`가 조용히 비어 있게 됩니다.
  *
  * Note: `@CreatedDate`, `@LastModifiedDate`는 [io.clroot.hibernate.reactive.spring.boot.auditing.AuditingEntityListener]를
  * 통해 처리됩니다. 엔티티에 `@EntityListeners(AuditingEntityListener::class)`를 추가해야 합니다.
@@ -36,6 +40,12 @@ public class AuditingAutoConfiguration {
     public fun reactiveAuditingHandler(
         auditorAware: ObjectProvider<ReactiveAuditorAware<*>>,
     ): ReactiveAuditingHandler<*> {
-        return ReactiveAuditingHandler(auditorAware.getIfAvailable())
+        val candidates = auditorAware.stream().toList()
+        check(candidates.size <= 1) {
+            "Expected at most one ReactiveAuditorAware bean but found ${candidates.size}. " +
+                    "Declare a single one, or define your own ReactiveAuditingHandler bean to choose between them."
+        }
+
+        return ReactiveAuditingHandler(candidates.firstOrNull())
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration.kt
@@ -1,27 +1,38 @@
 package io.clroot.hibernate.reactive.spring.boot.autoconfigure
 
+import io.clroot.hibernate.reactive.AmbientTransactionProbe
 import io.clroot.hibernate.reactive.ReactiveSessionProvider
 import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
 import io.clroot.hibernate.reactive.spring.boot.pool.SslAwareSqlClientPoolConfiguration
 import io.clroot.hibernate.reactive.spring.boot.transaction.HibernateReactiveTransactionManager
+import io.clroot.hibernate.reactive.spring.boot.transaction.SpringAmbientTransactionProbe
 import io.clroot.hibernate.reactive.spring.boot.transaction.TransactionalAwareSessionProvider
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import jakarta.persistence.Embeddable
 import jakarta.persistence.Entity
+import jakarta.persistence.MappedSuperclass
 import org.hibernate.cfg.AvailableSettings
 import org.hibernate.cfg.Configuration
 import org.hibernate.reactive.mutiny.Mutiny
 import org.hibernate.reactive.provider.ReactiveServiceRegistryBuilder
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.transaction.ReactiveTransactionManager
 import org.springframework.transaction.reactive.TransactionalEventPublisher
+import org.springframework.util.ClassUtils
 
 /**
  * Hibernate Reactive Auto-configuration.
@@ -58,11 +69,11 @@ public class HibernateReactiveAutoConfiguration(
     private val applicationContext: ApplicationContext,
     private val properties: HibernateReactiveProperties,
     // === 데이터소스 설정 ===
-    @Value("\${spring.datasource.url}") private val jdbcUrl: String,
-    @Value("\${spring.datasource.username}") private val username: String,
-    @Value("\${spring.datasource.password}") private val password: String,
+    @Value("\${spring.datasource.url:#{null}}") private val jdbcUrl: String?,
+    @Value("\${spring.datasource.username:#{null}}") private val username: String?,
+    @Value("\${spring.datasource.password:#{null}}") private val password: String?,
     // === JPA 기본 설정 ===
-    @Value("\${spring.jpa.database-platform}") private val dialect: String,
+    @Value("\${spring.jpa.database-platform:#{null}}") private val dialect: String?,
     @Value("\${spring.jpa.hibernate.ddl-auto:none}") private val ddlAuto: String,
     @Value("\${spring.jpa.show-sql:false}") private val showSql: Boolean,
     // === SQL 포맷팅 ===
@@ -94,23 +105,25 @@ public class HibernateReactiveAutoConfiguration(
     @Value("\${spring.jpa.properties.hibernate.cache.use_query_cache:false}") private val useQueryCache: Boolean,
 ) {
     @Bean
-    @ConditionalOnMissingBean(name = ["hibernateSessionFactory"])
+    @ConditionalOnMissingBean(value = [Mutiny.SessionFactory::class], name = ["hibernateSessionFactory"])
     public fun hibernateSessionFactory(): org.hibernate.SessionFactory {
-        val reactiveUrl = ReactiveConnectionUrl.fromJdbc(jdbcUrl)
+        val resolvedJdbcUrl = jdbcUrl?.takeIf { it.isNotBlank() } ?: throw IllegalStateException(
+            "Hibernate Reactive is on the classpath but 'spring.datasource.url' is not set. " +
+                    "Set it, define your own Mutiny.SessionFactory bean, or exclude " +
+                    "${javaClass.name} from auto-configuration.",
+        )
+        val reactiveUrl = ReactiveConnectionUrl.fromJdbc(resolvedJdbcUrl)
 
         val configuration =
             Configuration().apply {
                 // @SpringBootApplication 패키지 기준으로 @Entity 클래스 자동 스캔
                 val basePackages = AutoConfigurationPackages.get(applicationContext)
-                findEntityClasses(basePackages).forEach { entityClass ->
-                    addAnnotatedClass(entityClass)
+                findManagedClasses(basePackages).forEach { managedClass ->
+                    addManagedClass(this, managedClass)
                 }
             }
                 // === 기본 연결 설정 ===
                 .setProperty(AvailableSettings.JAKARTA_JDBC_URL, reactiveUrl)
-                .setProperty(AvailableSettings.JAKARTA_JDBC_USER, username)
-                .setProperty(AvailableSettings.JAKARTA_JDBC_PASSWORD, password)
-                .setProperty(AvailableSettings.DIALECT, dialect)
                 .setProperty(AvailableSettings.HBM2DDL_AUTO, ddlAuto)
                 // === SQL 로깅 설정 ===
                 .setProperty(AvailableSettings.SHOW_SQL, showSql.toString())
@@ -134,6 +147,15 @@ public class HibernateReactiveAutoConfiguration(
                 .setProperty("hibernate.connection.pool_size", properties.poolSize.toString())
 
         // === Optional Hibernate 설정 (null 가능) ===
+
+        // 자격 증명은 URL의 userinfo로도 전달될 수 있으므로 설정된 경우에만 적용합니다.
+        username?.let { configuration.setProperty(AvailableSettings.JAKARTA_JDBC_USER, it) }
+        password?.let { configuration.setProperty(AvailableSettings.JAKARTA_JDBC_PASSWORD, it) }
+
+        // Dialect가 없으면 Hibernate가 커넥션 메타데이터로 자동 판별합니다.
+        dialect?.takeIf { it.isNotBlank() }?.let {
+            configuration.setProperty(AvailableSettings.DIALECT, it)
+        }
 
         // Fetch 설정
         defaultBatchFetchSize?.let {
@@ -181,12 +203,18 @@ public class HibernateReactiveAutoConfiguration(
         }
 
         // JDBC URL 쿼리 파라미터에서 Hibernate 설정 추출
-        extractUrlParameter(jdbcUrl, "currentSchema")?.let {
+        extractUrlParameter(resolvedJdbcUrl, "currentSchema")?.let {
             configuration.setProperty(AvailableSettings.DEFAULT_SCHEMA, it)
         }
 
+        // 명시적으로 선언된 spring.jpa.properties.* 를 그대로 전달합니다.
+        // 위에서 계산한 기본값보다 사용자의 명시적 설정이 우선합니다.
+        passthroughJpaProperties().forEach { (key, value) ->
+            configuration.setProperty(key, value)
+        }
+
         // SSL 설정: 프로퍼티 우선, 없으면 URL 파라미터에서 추출
-        val sslMode = resolveSslMode()
+        val sslMode = resolveSslMode(resolvedJdbcUrl)
         if (sslMode != null && sslMode != "disable") {
             // 커스텀 SqlClientPoolConfiguration 등록
             configuration.setProperty(
@@ -219,7 +247,7 @@ public class HibernateReactiveAutoConfiguration(
      *
      * @return SSL 모드 문자열 또는 null
      */
-    private fun resolveSslMode(): String? {
+    private fun resolveSslMode(jdbcUrl: String): String? {
         // 1. 프로퍼티에서 명시적으로 설정된 경우 우선
         if (properties.sslMode != "disable") {
             return properties.sslMode
@@ -228,6 +256,18 @@ public class HibernateReactiveAutoConfiguration(
         // 2. URL 파라미터에서 sslmode 추출
         return extractSslModeFromUrl(jdbcUrl)
     }
+
+    /**
+     * `spring.jpa.properties.*` 로 선언된 모든 Hibernate 설정을 반환합니다.
+     *
+     * 이 스타터가 명시적으로 처리하는 `hibernate.reactive.*` 는 Hibernate가 알지 못하는
+     * 키이므로 제외합니다.
+     */
+    private fun passthroughJpaProperties(): Map<String, String> =
+        Binder.get(applicationContext.environment)
+            .bind(JPA_PROPERTIES_PREFIX, Bindable.mapOf(String::class.java, String::class.java))
+            .orElseGet(::emptyMap)
+            .filterKeys { !it.startsWith(REACTIVE_PROPERTIES_PREFIX) }
 
     /**
      * JDBC URL에서 sslmode 파라미터를 추출합니다.
@@ -264,11 +304,25 @@ public class HibernateReactiveAutoConfiguration(
 
     @Bean
     @ConditionalOnMissingBean
-    public fun reactiveTransactionExecutor(sessionFactory: Mutiny.SessionFactory): ReactiveTransactionExecutor =
-        ReactiveTransactionExecutor(sessionFactory)
+    public fun ambientTransactionProbe(sessionFactory: Mutiny.SessionFactory): AmbientTransactionProbe =
+        SpringAmbientTransactionProbe(sessionFactory)
 
     @Bean
     @ConditionalOnMissingBean
+    public fun reactiveTransactionExecutor(
+        sessionFactory: Mutiny.SessionFactory,
+        ambientTransactionProbe: AmbientTransactionProbe,
+    ): ReactiveTransactionExecutor =
+        ReactiveTransactionExecutor(sessionFactory, ambientTransactionProbe)
+
+    /**
+     * 다른 [ReactiveTransactionManager]가 이미 등록되어 있으면 물러납니다.
+     *
+     * 타입이 아닌 구현 클래스만 검사하면 R2DBC 등과 공존할 때 트랜잭션 매니저가 둘이 되어
+     * 첫 `@Transactional` 호출 시점에 `NoUniqueBeanDefinitionException`이 발생합니다.
+     */
+    @Bean
+    @ConditionalOnMissingBean(ReactiveTransactionManager::class)
     public fun hibernateReactiveTransactionManager(
         reactiveSessionFactory: Mutiny.SessionFactory,
     ): HibernateReactiveTransactionManager =
@@ -288,17 +342,53 @@ public class HibernateReactiveAutoConfiguration(
     ): TransactionalAwareSessionProvider =
         TransactionalAwareSessionProvider(sessionFactory)
 
-    private fun findEntityClasses(basePackages: List<String>): List<Class<*>> {
+    /**
+     * 영속성 유닛에 등록할 클래스들을 스캔합니다.
+     *
+     * `@Entity` 뿐 아니라 `@Embeddable`, `@MappedSuperclass`, `@Converter` 까지 등록해야
+     * Spring Boot의 블로킹 JPA와 동일한 매핑 결과를 얻을 수 있습니다.
+     * `@MappedSuperclass`는 보통 추상 클래스이므로 기본 후보 판별을 완화합니다.
+     */
+    private fun findManagedClasses(basePackages: List<String>): List<Class<*>> {
         val scanner =
-            ClassPathScanningCandidateComponentProvider(false).apply {
+            object : ClassPathScanningCandidateComponentProvider(false) {
+                override fun isCandidateComponent(beanDefinition: AnnotatedBeanDefinition): Boolean =
+                    beanDefinition.metadata.isIndependent
+            }.apply {
+                setResourceLoader(applicationContext)
                 addIncludeFilter(AnnotationTypeFilter(Entity::class.java))
+                addIncludeFilter(AnnotationTypeFilter(Embeddable::class.java))
+                addIncludeFilter(AnnotationTypeFilter(MappedSuperclass::class.java))
+                addIncludeFilter(AnnotationTypeFilter(Converter::class.java))
             }
 
-        return basePackages.flatMap { basePackage ->
-            scanner
-                .findCandidateComponents(basePackage)
-                .mapNotNull { it.beanClassName }
-                .map { Class.forName(it) }
+        val classLoader = applicationContext.classLoader ?: javaClass.classLoader
+
+        return basePackages
+            .flatMap { basePackage -> scanner.findCandidateComponents(basePackage) }
+            .mapNotNull { it.beanClassName }
+            .distinct()
+            .map { ClassUtils.forName(it, classLoader) }
+    }
+
+    /**
+     * 스캔된 클래스를 Hibernate [Configuration]에 등록합니다.
+     *
+     * `@Converter`는 전용 API를 사용해야 `autoApply` 속성이 반영됩니다.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun addManagedClass(configuration: Configuration, managedClass: Class<*>) {
+        if (managedClass.isAnnotationPresent(Converter::class.java) &&
+            AttributeConverter::class.java.isAssignableFrom(managedClass)
+        ) {
+            configuration.addAttributeConverter(managedClass as Class<out AttributeConverter<*, *>>)
+        } else {
+            configuration.addAnnotatedClass(managedClass)
         }
+    }
+
+    private companion object {
+        private const val JPA_PROPERTIES_PREFIX = "spring.jpa.properties"
+        private const val REACTIVE_PROPERTIES_PREFIX = "hibernate.reactive."
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties.kt
@@ -51,6 +51,10 @@ public data class HibernateReactiveProperties(
      * 이 시간 내에 커넥션을 획득하지 못하면 타임아웃 예외가 발생합니다.
      * null이면 Vert.x 기본값 사용
      *
+     * **프로덕션 권장**: [maxWaitQueueSize]와 함께 반드시 설정하세요.
+     * 둘 다 설정하지 않으면 대기 큐가 무제한이라, DB가 느려질 때 요청이 빠르게 실패하지 않고
+     * 계속 쌓여 애플리케이션 전체가 멈추는 브라운아웃으로 이어집니다.
+     *
      * @see org.hibernate.reactive.provider.Settings.POOL_CONNECT_TIMEOUT
      */
     val connectTimeout: Int? = null,
@@ -70,7 +74,10 @@ public data class HibernateReactiveProperties(
      *
      * 모든 커넥션이 사용 중일 때 대기할 수 있는 최대 요청 수입니다.
      * 대기 큐가 가득 차면 즉시 예외가 발생합니다.
-     * null이면 Vert.x 기본값 사용
+     * null이면 Vert.x 기본값(무제한) 사용
+     *
+     * **프로덕션 권장**: 무제한 대기 큐는 DB 지연 시 요청이 무한정 쌓이게 하므로
+     * [connectTimeout]과 함께 명시적으로 설정하세요.
      *
      * @see org.hibernate.reactive.provider.Settings.POOL_MAX_WAIT_QUEUE_SIZE
      */

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/CrudOperations.kt
@@ -22,11 +22,11 @@ import org.hibernate.reactive.mutiny.Mutiny
  */
 internal class CrudOperations<T : Any, ID : Any>(
     private val entityClass: Class<T>,
+    private val entityName: String,
     private val sessionProvider: TransactionalAwareSessionProvider,
     private val transactionExecutor: ReactiveTransactionExecutor,
     private val auditingHandler: ReactiveAuditingHandler<*>?,
 ) {
-    private val entityName: String = entityClass.simpleName
 
     private suspend fun prepareEntity(entity: T): Boolean {
         val isNew = EntityStateDetector.isNew(entity)
@@ -140,11 +140,18 @@ internal class CrudOperations<T : Any, ID : Any>(
     // Delete 작업
     // ============================================
 
+    /**
+     * 엔티티를 로드한 뒤 제거합니다.
+     *
+     * bulk `DELETE` 문은 cascade, `@Version` 낙관적 락, 영속성 컨텍스트 정리를 모두 건너뛰므로
+     * Spring Data JPA와 동일하게 로드 후 제거하는 방식을 사용합니다.
+     * 대상이 없으면 조용히 무시합니다.
+     */
     suspend fun deleteById(id: ID) {
         sessionProvider.write<Unit> { session ->
-            session.createMutationQuery("DELETE FROM $entityName e WHERE e.id = :id")
-                .setParameter("id", RepositoryIdAdapter.unwrap(id))
-                .executeUpdate()
+            session.find(entityClass, RepositoryIdAdapter.unwrap(id))
+                .onItem()
+                .transformToUni { entity: T? -> removeIfPresent(session, entity) }
                 .replaceWith(Unit)
         }
     }
@@ -161,9 +168,10 @@ internal class CrudOperations<T : Any, ID : Any>(
         if (idList.isEmpty()) return
 
         sessionProvider.write<Unit> { session ->
-            session.createMutationQuery("DELETE FROM $entityName e WHERE e.id IN :ids")
+            session.createQuery("FROM $entityName e WHERE e.id IN :ids", entityClass)
                 .setParameter("ids", idList)
-                .executeUpdate()
+                .resultList
+                .chain { entities -> removeAll(session, entities) }
                 .replaceWith(Unit)
         }
     }
@@ -183,9 +191,21 @@ internal class CrudOperations<T : Any, ID : Any>(
 
     suspend fun deleteAll() {
         sessionProvider.write<Unit> { session ->
-            session.createMutationQuery("DELETE FROM $entityName")
-                .executeUpdate()
+            session.createQuery("FROM $entityName e", entityClass)
+                .resultList
+                .chain { entities -> removeAll(session, entities) }
                 .replaceWith(Unit)
         }
     }
+
+    private fun removeIfPresent(session: Mutiny.Session, entity: T?): Uni<Void> =
+        if (entity == null) Uni.createFrom().voidItem() else session.remove(entity)
+
+    private fun removeAll(session: Mutiny.Session, entities: List<T>): Uni<Void> =
+        if (entities.isEmpty()) {
+            Uni.createFrom().voidItem()
+        } else {
+            val managed: List<Any> = entities
+            session.removeAll(*managed.toTypedArray())
+        }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoriesRegistrarSelector.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoriesRegistrarSelector.kt
@@ -18,20 +18,39 @@ public class HibernateReactiveRepositoriesRegistrarSelector : ImportBeanDefiniti
             EnableHibernateReactiveRepositories::class.java.name,
         ) ?: return
 
-        val basePackages = resolveBasePackages(attributes, importingClassMetadata)
+        val declaredPackages = resolveBasePackages(attributes, importingClassMetadata)
 
-        // 기존에 등록된 auto-config registrar가 있으면 제거
-        if (registry.containsBeanDefinition("hibernateReactiveRepositoryRegistrar")) {
-            registry.removeBeanDefinition("hibernateReactiveRepositoryRegistrar")
+        // 여러 설정 클래스가 각자 @EnableHibernateReactiveRepositories를 선언할 수 있으므로,
+        // 앞서 처리된 선언의 패키지와 합친다. 덮어쓰면 먼저 처리된 모듈의 Repository가 등록되지 않는다.
+        val basePackages = (previouslyDeclaredPackages(registry) + declaredPackages).distinct()
+
+        // auto-config가 등록한 기본 registrar 또는 이전 선언의 registrar를 대체한다
+        if (registry.containsBeanDefinition(REGISTRAR_BEAN_NAME)) {
+            registry.removeBeanDefinition(REGISTRAR_BEAN_NAME)
         }
 
-        // 커스텀 패키지로 새 registrar 등록
         val beanDefinition = BeanDefinitionBuilder
             .genericBeanDefinition(HibernateReactiveRepositoryRegistrar::class.java)
             .addConstructorArgValue(basePackages)
             .beanDefinition
+            .apply { setAttribute(DECLARED_PACKAGES_ATTRIBUTE, basePackages) }
 
-        registry.registerBeanDefinition("hibernateReactiveRepositoryRegistrar", beanDefinition)
+        registry.registerBeanDefinition(REGISTRAR_BEAN_NAME, beanDefinition)
+    }
+
+    /**
+     * 이전 `@EnableHibernateReactiveRepositories` 선언이 등록한 패키지를 반환합니다.
+     *
+     * auto-config가 등록한 기본 registrar에는 이 속성이 없으므로 빈 목록이 반환되고,
+     * 결과적으로 명시적 선언이 기본 스캔을 대체합니다.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun previouslyDeclaredPackages(registry: BeanDefinitionRegistry): List<String> {
+        if (!registry.containsBeanDefinition(REGISTRAR_BEAN_NAME)) return emptyList()
+
+        return registry.getBeanDefinition(REGISTRAR_BEAN_NAME)
+            .getAttribute(DECLARED_PACKAGES_ATTRIBUTE) as? List<String>
+            ?: emptyList()
     }
 
     private fun resolveBasePackages(
@@ -53,11 +72,19 @@ public class HibernateReactiveRepositoriesRegistrarSelector : ImportBeanDefiniti
         }
 
         // 아무것도 지정되지 않으면 어노테이션이 붙은 클래스의 패키지 사용
+        // (클래스를 로딩하면 앱 클래스로더와 어긋날 수 있으므로 이름에서 패키지를 얻는다)
         if (packages.isEmpty()) {
-            val className = importingClassMetadata.className
-            packages.add(Class.forName(className).packageName)
+            packages.add(importingClassMetadata.className.substringBeforeLast('.', ""))
         }
 
         return packages.toList()
+    }
+
+    private companion object {
+        private const val REGISTRAR_BEAN_NAME = "hibernateReactiveRepositoryRegistrar"
+
+        /** 이 selector가 등록한 정의임을 표시하고, 누적된 패키지를 담는다. */
+        private const val DECLARED_PACKAGES_ATTRIBUTE =
+            "io.clroot.hibernate.reactive.declaredBasePackages"
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBean.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBean.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.FactoryBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.GenericTypeResolver
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 
 /**
@@ -36,9 +37,10 @@ public class HibernateReactiveRepositoryFactoryBean<T : CoroutineCrudRepository<
     @Suppress("UNCHECKED_CAST")
     override fun getObject(): T {
         val (entityClass, idClass) = extractGenericTypes(repositoryInterface)
+        val entityName = resolveEntityName(entityClass)
 
         // 커스텀 쿼리 메서드 파싱
-        val queryMethods = parseQueryMethods(entityClass)
+        val queryMethods = parseQueryMethods(entityClass, entityName)
 
         val handler = SimpleHibernateReactiveRepository(
             entityClass = entityClass as Class<Any>,
@@ -47,6 +49,7 @@ public class HibernateReactiveRepositoryFactoryBean<T : CoroutineCrudRepository<
             transactionExecutor = transactionExecutor,
             queryMethods = queryMethods,
             auditingHandler = auditingHandler,
+            entityName = entityName,
         )
 
         return Proxy.newProxyInstance(
@@ -83,14 +86,75 @@ public class HibernateReactiveRepositoryFactoryBean<T : CoroutineCrudRepository<
 
     /**
      * Repository 인터페이스의 커스텀 쿼리 메서드들을 파싱합니다.
+     *
+     * 런타임 라우팅은 메서드명과 인자 개수만으로 이루어지므로, 실행 불가능한 선언은
+     * 여기서 모두 거부합니다.
      */
-    private fun parseQueryMethods(entityClass: Class<*>): Map<String, PreparedQueryMethod> {
-        val parser = QueryMethodParser(entityClass)
+    /**
+     * HQL에 사용할 엔티티 이름을 JPA 메타모델에서 조회합니다.
+     *
+     * `@Entity(name = "...")`로 이름을 바꿨거나 서로 다른 패키지에 같은 단순 이름의 엔티티가
+     * 있으면 클래스의 단순 이름은 올바른 HQL을 만들지 못합니다.
+     */
+    private fun resolveEntityName(entityClass: Class<*>): String =
+        try {
+            sessionProvider.metamodel.entity(entityClass).name
+        } catch (e: IllegalArgumentException) {
+            throw IllegalStateException(
+                "${entityClass.name} is not a managed entity. " +
+                        "Repository '${repositoryInterface.name}' requires its entity type to be registered " +
+                        "with the Hibernate Reactive session factory.",
+                e,
+            )
+        }
 
-        return repositoryInterface.methods
-            .filter { parser.isCustomQueryMethod(it) }
-            .associate { method ->
-                parser.createMethodKey(method) to parser.parse(method)
+    private fun parseQueryMethods(
+        entityClass: Class<*>,
+        entityName: String,
+    ): Map<String, PreparedQueryMethod> {
+        val parser = QueryMethodParser(entityClass, entityName)
+        val declaredMethods = repositoryInterface.methods
+            .filter { parser.isDeclaredRepositoryMethod(it) }
+
+        rejectNonSuspendMethods(parser, declaredMethods)
+
+        val queryMethods = declaredMethods.filter { parser.isSuspendMethod(it) }
+        rejectAmbiguousOverloads(parser, queryMethods)
+
+        return queryMethods.associate { method ->
+            parser.createMethodKey(method) to parser.parse(method)
+        }
+    }
+
+    private fun rejectNonSuspendMethods(parser: QueryMethodParser, methods: List<Method>) {
+        val offender = methods.firstOrNull { !parser.isSuspendMethod(it) } ?: return
+
+        throw IllegalStateException(
+            "Repository method '${repositoryInterface.name}.${offender.name}' must be a suspend function. " +
+                    "Non-suspend query methods (including Flow-returning ones) are not supported; " +
+                    "declare it as 'suspend fun ${offender.name}(...): List<T>' instead.",
+        )
+    }
+
+    /**
+     * 런타임 조회 키가 `이름#인자수`이므로, 같은 이름과 인자 개수를 가진 오버로드는
+     * 어느 쪽이 선택될지 결정되지 않습니다.
+     */
+    private fun rejectAmbiguousOverloads(parser: QueryMethodParser, methods: List<Method>) {
+        methods
+            .groupBy { parser.createMethodKey(it) }
+            .forEach { (key, overloads) ->
+                val distinctSignatures = overloads.distinctBy { it.parameterTypes.toList() }
+                if (distinctSignatures.size > 1) {
+                    val signatures = distinctSignatures.joinToString(", ") { method ->
+                        method.parameterTypes.dropLast(1).joinToString(", ") { it.simpleName }
+                    }
+                    throw IllegalStateException(
+                        "Repository '${repositoryInterface.name}' declares ambiguous overloads for '$key': " +
+                                "[$signatures]. Query methods are resolved by name and argument count, " +
+                                "so overloads with the same argument count are not supported.",
+                    )
+                }
             }
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/PaginationOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/PaginationOperations.kt
@@ -19,10 +19,10 @@ import org.springframework.data.domain.Sort
  */
 internal class PaginationOperations<T : Any>(
     private val entityClass: Class<T>,
+    private val entityName: String,
     private val sessionProvider: TransactionalAwareSessionProvider,
     private val queryOps: QueryOperations<T>,
 ) {
-    private val entityName: String = entityClass.simpleName
 
     // ============================================
     // 기본 findAll with Pageable/Sort
@@ -112,11 +112,13 @@ internal class PaginationOperations<T : Any>(
         args: List<Any?>,
         pageable: Pageable,
     ): Page<T> {
+        val hql = queryOps.applyAnnotatedQuerySort(prepared, pageable.sort)
+
         val content = sessionProvider.read { session ->
             val query = if (prepared.isNativeQuery) {
-                session.createNativeQuery(prepared.hql, entityClass)
+                session.createNativeQuery(hql, entityClass)
             } else {
-                session.createQuery(prepared.hql, entityClass)
+                session.createQuery(hql, entityClass)
             }
 
             queryOps.bindAnnotatedParameters(query, prepared, args)
@@ -142,11 +144,13 @@ internal class PaginationOperations<T : Any>(
         args: List<Any?>,
         pageable: Pageable,
     ): Slice<T> {
+        val hql = queryOps.applyAnnotatedQuerySort(prepared, pageable.sort)
+
         val content = sessionProvider.read { session ->
             val query = if (prepared.isNativeQuery) {
-                session.createNativeQuery(prepared.hql, entityClass)
+                session.createNativeQuery(hql, entityClass)
             } else {
-                session.createQuery(prepared.hql, entityClass)
+                session.createQuery(hql, entityClass)
             }
 
             queryOps.bindAnnotatedParameters(query, prepared, args)

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParser.kt
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Slice
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.query.parser.PartTree
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
@@ -32,8 +33,8 @@ import kotlin.reflect.jvm.kotlinFunction
  */
 internal class QueryMethodParser(
     private val entityClass: Class<*>,
+    private val entityName: String = entityClass.simpleName,
 ) {
-    private val entityName: String = entityClass.simpleName
 
     companion object {
         /** CoroutineCrudRepository의 기본 메서드 이름들 */
@@ -65,17 +66,27 @@ internal class QueryMethodParser(
     /**
      * 커스텀 쿼리 메서드인지 확인합니다.
      */
-    fun isCustomQueryMethod(method: Method): Boolean {
-        // 기본 메서드는 제외
+    fun isCustomQueryMethod(method: Method): Boolean =
+        isDeclaredRepositoryMethod(method) && isSuspendMethod(method)
+
+    /**
+     * 사용자가 Repository 인터페이스에 직접 선언한 메서드인지 확인합니다.
+     *
+     * 기본 CRUD 메서드, `Object` 메서드, default/static/bridge 메서드는 제외합니다.
+     */
+    fun isDeclaredRepositoryMethod(method: Method): Boolean {
         if (method.name in BASE_METHODS) return false
-
-        // Object 클래스의 메서드는 제외
         if (method.declaringClass == Any::class.java) return false
-
-        // Default 메서드는 제외
         if (method.isDefault) return false
+        if (method.isSynthetic || method.isBridge) return false
+        if (Modifier.isStatic(method.modifiers)) return false
+        return true
+    }
 
-        // suspend 함수인지 확인 (마지막 파라미터가 Continuation)
+    /**
+     * suspend 함수인지 확인합니다 (마지막 파라미터가 Continuation).
+     */
+    fun isSuspendMethod(method: Method): Boolean {
         val params = method.parameterTypes
         return params.isNotEmpty() && Continuation::class.java.isAssignableFrom(params.last())
     }
@@ -119,6 +130,7 @@ internal class QueryMethodParser(
             ?: QueryParameters(ParameterStyle.NONE)
         val argumentNames = extractParameterNames(method)
         validateQueryParameters(method, queryParameters, countParameters, argumentNames)
+        validateAnnotatedResultType(method, returnType)
 
         return PreparedQueryMethod(
             method = method,
@@ -216,11 +228,27 @@ internal class QueryMethodParser(
             )
         }
 
+        val maxResults = partTree.maxResults
+        if (maxResults != null && hasPageable) {
+            throw IllegalStateException(
+                "Method '${method.name}' combines a Top/First limit with a Pageable parameter, " +
+                        "which is ambiguous. Use either the limit keyword or Pageable, not both.",
+            )
+        }
+
         val builder = PartTreeHqlBuilder(entityName, partTree)
         val buildResult = if (hasPageable || hasSort) {
             builder.buildWithSort(null)
         } else {
             builder.build()
+        }
+
+        val declaredArgumentCount = queryArgumentCount(method)
+        if (buildResult.parameterBinders.size != declaredArgumentCount) {
+            throw IllegalStateException(
+                "Method '${method.name}' derives ${buildResult.parameterBinders.size} query parameter(s) " +
+                        "from its name but declares $declaredArgumentCount argument(s)",
+            )
         }
 
         val countHql = if (returnType == QueryReturnType.PAGE) {
@@ -241,6 +269,7 @@ internal class QueryMethodParser(
             isModifying = false,
             parameterStyle = ParameterStyle.NONE,
             parameterNames = emptyList(),
+            maxResults = maxResults,
         )
     }
 
@@ -248,11 +277,28 @@ internal class QueryMethodParser(
         return when {
             partTree.isExistsProjection -> QueryReturnType.BOOLEAN
             partTree.isCountProjection -> QueryReturnType.LONG
-            partTree.isDelete -> QueryReturnType.VOID
+            partTree.isDelete -> determineDeleteReturnType(method)
             isPageReturnType(method) -> QueryReturnType.PAGE
             isSliceReturnType(method) -> QueryReturnType.SLICE
             isListReturnType(method) -> QueryReturnType.LIST
             else -> QueryReturnType.SINGLE
+        }
+    }
+
+    /**
+     * 파생 `deleteBy...` 메서드의 반환 타입을 결정합니다.
+     *
+     * Spring Data와 동일하게 `Unit`, `Int`, `Long` 반환을 지원합니다.
+     */
+    private fun determineDeleteReturnType(method: Method): QueryReturnType {
+        val actualReturnType = extractActualReturnType(method) ?: return QueryReturnType.VOID
+        return when {
+            isAssignableToRawType(actualReturnType, Int::class.javaObjectType) -> QueryReturnType.MODIFYING
+            isAssignableToRawType(actualReturnType, Long::class.javaObjectType) -> QueryReturnType.LONG
+            isAssignableToRawType(actualReturnType, Unit::class.java) -> QueryReturnType.VOID
+            else -> throw IllegalStateException(
+                "Derived delete method '${method.name}' must return Unit, Int or Long",
+            )
         }
     }
 
@@ -317,6 +363,50 @@ internal class QueryMethodParser(
                         "but has only $argumentCount query arguments",
             )
         }
+    }
+
+    /**
+     * 쿼리 인자 개수를 셉니다. Continuation과 Pageable/Sort는 쿼리 인자가 아닙니다.
+     */
+    private fun queryArgumentCount(method: Method): Int =
+        method.parameters.count { param ->
+            param.type != Continuation::class.java &&
+                    !Pageable::class.java.isAssignableFrom(param.type) &&
+                    !Sort::class.java.isAssignableFrom(param.type)
+        }
+
+    /**
+     * `@Query` 메서드가 엔티티 결과를 반환하는지 검증합니다.
+     *
+     * 현재 실행 경로는 결과 타입을 엔티티 클래스로 고정하므로, 스칼라/집계/DTO 프로젝션은
+     * 런타임에 Hibernate 내부 오류로 실패합니다. 시작 시점에 명확히 거부합니다.
+     */
+    private fun validateAnnotatedResultType(method: Method, returnType: QueryReturnType) {
+        if (returnType == QueryReturnType.MODIFYING || returnType == QueryReturnType.VOID) return
+
+        val actualReturnType = extractActualReturnType(method) ?: return
+        val resultType = when (returnType) {
+            QueryReturnType.SINGLE -> actualReturnType
+            else -> firstTypeArgument(actualReturnType) ?: return
+        }
+        val rawResultType = rawClassOf(resultType) ?: return
+
+        if (!rawResultType.isAssignableFrom(entityClass)) {
+            throw IllegalStateException(
+                "@Query method '${method.name}' declares result type ${rawResultType.simpleName} " +
+                        "but only the entity type ${entityClass.simpleName} (or a List/Page/Slice of it) " +
+                        "is supported. Scalar, aggregate and DTO projections are not supported yet.",
+            )
+        }
+    }
+
+    private fun firstTypeArgument(type: Type): Type? =
+        (type as? ParameterizedType)?.actualTypeArguments?.firstOrNull()?.let(::unwrapWildcard)
+
+    private fun rawClassOf(type: Type): Class<*>? = when (type) {
+        is Class<*> -> type
+        is ParameterizedType -> type.rawType as? Class<*>
+        else -> null
     }
 
     private fun extractParameterNames(method: Method): List<String> {

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryOperations.kt
@@ -1,7 +1,9 @@
 package io.clroot.hibernate.reactive.spring.boot.repository
 
+import io.clroot.hibernate.reactive.spring.boot.repository.query.CountQueryDeriver
 import io.clroot.hibernate.reactive.spring.boot.repository.query.Modifying
 import io.clroot.hibernate.reactive.spring.boot.repository.query.ParameterStyle
+import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryAliasResolver
 import io.clroot.hibernate.reactive.spring.boot.repository.query.PreparedQueryMethod
 import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryConstants.ORDER_BY_REGEX
 import io.clroot.hibernate.reactive.spring.boot.repository.query.QueryReturnType
@@ -10,6 +12,7 @@ import jakarta.persistence.metamodel.Attribute
 import jakarta.persistence.metamodel.ManagedType
 import jakarta.persistence.metamodel.Metamodel
 import jakarta.persistence.metamodel.PluralAttribute
+import io.smallrye.mutiny.Uni
 import jakarta.persistence.metamodel.SingularAttribute
 import org.hibernate.reactive.mutiny.Mutiny
 import org.springframework.data.domain.Pageable
@@ -36,17 +39,19 @@ internal class QueryOperations<T : Any>(
     // PartTree 쿼리 실행
     // ============================================
 
-    suspend fun executeSingleQuery(hql: String, args: List<Any?>): T? =
+    suspend fun executeSingleQuery(hql: String, args: List<Any?>, maxResults: Int? = null): T? =
         sessionProvider.read { session ->
             val query = session.createQuery(hql, entityClass)
             bindIndexedParameters(query, args)
+            maxResults?.let { query.maxResults = it }
             query.singleResultOrNull
         }
 
-    suspend fun executeListQuery(hql: String, args: List<Any?>): List<T> =
+    suspend fun executeListQuery(hql: String, args: List<Any?>, maxResults: Int? = null): List<T> =
         sessionProvider.read { session ->
             val query = session.createQuery(hql, entityClass)
             bindIndexedParameters(query, args)
+            maxResults?.let { query.maxResults = it }
             query.resultList
         }
 
@@ -66,13 +71,25 @@ internal class QueryOperations<T : Any>(
             query.singleResult
         } ?: 0L
 
-    suspend fun executeDeleteQuery(hql: String, args: List<Any?>) {
-        sessionProvider.write<Unit> { session ->
-            val query = session.createMutationQuery(hql)
+    /**
+     * 파생 `deleteBy...` 쿼리를 실행하고 삭제된 행 수를 반환합니다.
+     *
+     * 대상 엔티티를 먼저 로드한 뒤 제거하므로 cascade와 `@Version`이 정상 동작합니다.
+     */
+    suspend fun executeDeleteQuery(hql: String, args: List<Any?>): Long =
+        sessionProvider.write { session ->
+            val query = session.createQuery(hql, entityClass)
             bindIndexedParameters(query, args)
-            query.executeUpdate().replaceWith(Unit)
+            query.resultList.chain { entities ->
+                if (entities.isEmpty()) {
+                    Uni.createFrom().item(0L)
+                } else {
+                    val managed: List<Any> = entities
+                    session.removeAll(*managed.toTypedArray())
+                        .replaceWith(entities.size.toLong())
+                }
+            }
         }
-    }
 
     suspend fun executeListQueryWithSort(
         prepared: PreparedQueryMethod,
@@ -80,7 +97,7 @@ internal class QueryOperations<T : Any>(
         sort: Sort,
     ): List<T> {
         val hql = applyDynamicSort(prepared.hql, sort)
-        return executeListQuery(hql, args)
+        return executeListQuery(hql, args, prepared.maxResults)
     }
 
     // ============================================
@@ -116,12 +133,15 @@ internal class QueryOperations<T : Any>(
     suspend fun executeListAnnotatedQuery(
         prepared: PreparedQueryMethod,
         args: List<Any?>,
+        sort: Sort = Sort.unsorted(),
     ): List<T> {
+        val hql = applyAnnotatedQuerySort(prepared, sort)
+
         return sessionProvider.read { session ->
             val query = if (prepared.isNativeQuery) {
-                session.createNativeQuery(prepared.hql, entityClass)
+                session.createNativeQuery(hql, entityClass)
             } else {
-                session.createQuery(prepared.hql, entityClass)
+                session.createQuery(hql, entityClass)
             }
 
             bindAnnotatedParameters(query, prepared, args)
@@ -247,7 +267,39 @@ internal class QueryOperations<T : Any>(
         return "$baseHql ORDER BY $sortClause"
     }
 
-    internal fun buildSortClause(sort: Sort): String {
+    /**
+     * `@Query`로 선언된 쿼리에 동적 [Sort]를 적용합니다.
+     *
+     * 쿼리가 이미 `ORDER BY`를 갖고 있으면 뒤에 덧붙여 작성자의 정렬 의도를 보존합니다.
+     * 안전하게 적용할 수 없으면 조용히 무시하지 않고 예외를 던집니다.
+     */
+    internal fun applyAnnotatedQuerySort(prepared: PreparedQueryMethod, sort: Sort): String {
+        if (sort.isUnsorted) return prepared.hql
+
+        if (prepared.isNativeQuery) {
+            throw UnsupportedOperationException(
+                "Sorting a native @Query is not supported for method '${prepared.method.name}'. " +
+                        "Declare the ORDER BY clause inside the query instead.",
+            )
+        }
+
+        val alias = QueryAliasResolver.resolve(prepared.hql)
+            ?: throw IllegalStateException(
+                "Cannot apply Sort to @Query method '${prepared.method.name}' because its root alias " +
+                        "could not be determined. Declare the ORDER BY clause inside the query instead.",
+            )
+
+        val sortClause = buildSortClause(sort, alias)
+        val baseHql = prepared.hql.trimEnd()
+
+        return if (CountQueryDeriver.hasOrderBy(baseHql)) {
+            "$baseHql, $sortClause"
+        } else {
+            "$baseHql ORDER BY $sortClause"
+        }
+    }
+
+    internal fun buildSortClause(sort: Sort, alias: String = "e"): String {
         if (sort.isUnsorted) return ""
         return sort.map { order ->
             val direction = if (order.isAscending) "ASC" else "DESC"
@@ -277,7 +329,7 @@ internal class QueryOperations<T : Any>(
                     throw IllegalArgumentException("Sort property must resolve to a basic attribute")
                 }
             }
-            "e.${order.property} $direction"
+            "$alias.${order.property} $direction"
         }.joinToString(", ")
     }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository.kt
@@ -40,6 +40,7 @@ public class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
     private val transactionExecutor: ReactiveTransactionExecutor,
     private val queryMethods: Map<String, PreparedQueryMethod> = emptyMap(),
     auditingHandler: ReactiveAuditingHandler<*>? = null,
+    entityName: String = entityClass.simpleName,
 ) : InvocationHandler {
 
     public companion object {
@@ -56,9 +57,10 @@ public class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
     }
 
     // 내부 헬퍼 클래스들
-    private val crud = CrudOperations<T, ID>(entityClass, sessionProvider, transactionExecutor, auditingHandler)
+    private val crud =
+        CrudOperations<T, ID>(entityClass, entityName, sessionProvider, transactionExecutor, auditingHandler)
     private val query = QueryOperations<T>(entityClass, sessionProvider)
-    private val pagination = PaginationOperations<T>(entityClass, sessionProvider, query)
+    private val pagination = PaginationOperations<T>(entityClass, entityName, sessionProvider, query)
 
     // ============================================
     // InvocationHandler 구현
@@ -197,7 +199,7 @@ public class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
 
         // @Query 어노테이션 메서드 처리
         if (prepared.isAnnotatedQuery) {
-            return executeAnnotatedQuery(prepared, queryArgs, pageable)
+            return executeAnnotatedQuery(prepared, queryArgs, pageable, sort)
         }
 
         // PartTree 기반 쿼리 처리
@@ -205,19 +207,31 @@ public class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
             prepared.parameterBinders.getOrNull(index)?.bind(arg) ?: arg
         }
 
+        // 파생 deleteBy는 대상을 로드한 뒤 제거하므로 삭제 건수를 선언된 반환 타입으로 변환합니다.
+        if (prepared.partTree?.isDelete == true) {
+            val deletedCount = query.executeDeleteQuery(prepared.hql, boundArgs)
+            return when (prepared.returnType) {
+                QueryReturnType.MODIFYING -> deletedCount.toInt()
+                QueryReturnType.LONG -> deletedCount
+                else -> Unit
+            }
+        }
+
         return when (prepared.returnType) {
-            QueryReturnType.SINGLE -> query.executeSingleQuery(prepared.hql, boundArgs)
+            QueryReturnType.SINGLE -> query.executeSingleQuery(prepared.hql, boundArgs, prepared.maxResults)
             QueryReturnType.LIST -> {
                 if (sort != null) {
                     query.executeListQueryWithSort(prepared, boundArgs, sort)
                 } else {
-                    query.executeListQuery(prepared.hql, boundArgs)
+                    query.executeListQuery(prepared.hql, boundArgs, prepared.maxResults)
                 }
             }
 
             QueryReturnType.BOOLEAN -> query.executeExistsQuery(prepared.hql, boundArgs)
             QueryReturnType.LONG -> query.executeCountQuery(prepared.hql, boundArgs)
-            QueryReturnType.VOID -> query.executeDeleteQuery(prepared.hql, boundArgs)
+            QueryReturnType.VOID -> throw IllegalStateException(
+                "VOID return type is only produced by derived delete methods",
+            )
             QueryReturnType.PAGE -> pagination.executePageQuery(prepared, boundArgs, pageable!!)
             QueryReturnType.SLICE -> pagination.executeSliceQuery(prepared, boundArgs, pageable!!)
             QueryReturnType.MODIFYING -> throw IllegalStateException("MODIFYING should be handled by executeAnnotatedQuery")
@@ -228,6 +242,7 @@ public class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
         prepared: PreparedQueryMethod,
         args: List<Any?>,
         pageable: Pageable?,
+        sort: Sort?,
     ): Any? {
         return when (prepared.returnType) {
             QueryReturnType.MODIFYING -> query.executeModifyingAnnotatedQuery(prepared, args)
@@ -237,7 +252,7 @@ public class SimpleHibernateReactiveRepository<T : Any, ID : Any>(
             }
             QueryReturnType.PAGE -> pagination.executePageAnnotatedQuery(prepared, args, pageable!!)
             QueryReturnType.SLICE -> pagination.executeSliceAnnotatedQuery(prepared, args, pageable!!)
-            QueryReturnType.LIST -> query.executeListAnnotatedQuery(prepared, args)
+            QueryReturnType.LIST -> query.executeListAnnotatedQuery(prepared, args, sort ?: Sort.unsorted())
             QueryReturnType.SINGLE -> query.executeSingleAnnotatedQuery(prepared, args)
             else -> throw IllegalStateException("Unsupported return type for @Query: ${prepared.returnType}")
         }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriver.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/CountQueryDeriver.kt
@@ -175,6 +175,14 @@ internal object CountQueryDeriver {
         )
     }
 
+    /**
+     * 최상위 `ORDER BY` 절이 있는지 확인합니다.
+     *
+     * 문자열 리터럴과 주석 안의 키워드는 [scan]이 걸러내므로 오탐이 없습니다.
+     */
+    fun hasOrderBy(query: String): Boolean =
+        scan(query).tokens.findSequence(query, "ORDER", "BY") != null
+
     private fun unsupported(feature: String): Nothing {
         throw IllegalStateException(
             "Automatic count query derivation does not support $feature; declare countQuery explicitly",

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/ParameterBinder.kt
@@ -26,24 +26,39 @@ public sealed class ParameterBinder {
      * LIKE 패턴 바인더 - 값 양쪽에 % 추가
      */
     public data object Containing : ParameterBinder() {
-        override fun bind(value: Any?): Any? = value?.let { "%$it%" }
+        override fun bind(value: Any?): Any? = value?.let { "%${escapeLikeWildcards(it)}%" }
     }
 
     /**
      * StartingWith 패턴 바인더 - 값 뒤에 % 추가
      */
     public data object StartingWith : ParameterBinder() {
-        override fun bind(value: Any?): Any? = value?.let { "$it%" }
+        override fun bind(value: Any?): Any? = value?.let { "${escapeLikeWildcards(it)}%" }
     }
 
     /**
      * EndingWith 패턴 바인더 - 값 앞에 % 추가
      */
     public data object EndingWith : ParameterBinder() {
-        override fun bind(value: Any?): Any? = value?.let { "%$it" }
+        override fun bind(value: Any?): Any? = value?.let { "%${escapeLikeWildcards(it)}" }
     }
 
     public companion object {
+        /**
+         * LIKE 패턴에서 특별한 의미를 갖는 문자를 이스케이프합니다.
+         *
+         * 이스케이프하지 않으면 `findByNameContaining("%")` 같은 호출이 전체 행을 매칭하여
+         * 의도한 필터를 우회합니다. [LIKE_ESCAPE_CHARACTER]와 짝을 이룹니다.
+         */
+        internal fun escapeLikeWildcards(value: Any): String =
+            value.toString()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_")
+
+        /** 이스케이프된 LIKE 패턴에 사용할 HQL `ESCAPE` 절. */
+        internal const val LIKE_ESCAPE_CLAUSE: String = " ESCAPE '\\'"
+
         /**
          * Part.Type에 맞는 ParameterBinder를 반환합니다.
          */

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PartTreeHqlBuilder.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PartTreeHqlBuilder.kt
@@ -18,6 +18,9 @@ internal class PartTreeHqlBuilder(
 
     companion object {
         private val SAFE_PROPERTY_PATH = Regex("[\\p{L}_$][\\p{L}\\p{N}_$]*(\\.[\\p{L}_$][\\p{L}\\p{N}_$]*)*")
+
+        /** 이 빌더가 직접 생성하는 파라미터 플레이스홀더. 사용자 입력이 아니므로 치환이 안전합니다. */
+        private val PARAMETER_PLACEHOLDER = Regex(":p\\d+")
     }
 
     private var parameterIndex = 0
@@ -81,6 +84,7 @@ internal class PartTreeHqlBuilder(
         val orderBy = buildOrderByClause(effectiveSort)
 
         return buildString {
+            if (partTree.isDistinct) append("SELECT DISTINCT e ")
             append("FROM $entityName e")
             if (where.isNotEmpty()) append(" WHERE $where")
             if (orderBy.isNotEmpty()) append(" ORDER BY $orderBy")
@@ -89,18 +93,25 @@ internal class PartTreeHqlBuilder(
 
     private fun buildCountQuery(): String {
         val where = buildWhereClause()
+        val countExpression = if (partTree.isDistinct) "COUNT(DISTINCT e)" else "COUNT(e)"
         return buildString {
-            append("SELECT COUNT(e) FROM $entityName e")
+            append("SELECT $countExpression FROM $entityName e")
             if (where.isNotEmpty()) append(" WHERE $where")
         }
     }
 
     private fun buildExistsQuery(): String = buildCountQuery()
 
+    /**
+     * 파생 `deleteBy...` 메서드가 삭제할 엔티티를 조회하는 SELECT를 생성합니다.
+     *
+     * bulk `DELETE` 문은 cascade와 `@Version`을 건너뛰므로, Spring Data JPA와 동일하게
+     * 대상을 로드한 뒤 하나씩 제거합니다.
+     */
     private fun buildDeleteQuery(): String {
         val where = buildWhereClause()
         return buildString {
-            append("DELETE FROM $entityName e")
+            append("FROM $entityName e")
             if (where.isNotEmpty()) append(" WHERE $where")
         }
     }
@@ -128,14 +139,44 @@ internal class PartTreeHqlBuilder(
      * [ConditionBuilderRegistry]를 통해 적절한 빌더를 조회하여 위임합니다.
      */
     private fun buildCondition(part: Part): String {
-        val property = "e.${part.property.toDotPath()}"
+        val propertyPath = "e.${part.property.toDotPath()}"
+        val ignoreCase = shouldIgnoreCase(part)
         val builder = ConditionBuilderRegistry.get(part.type)
+        val property = if (ignoreCase) "LOWER($propertyPath)" else propertyPath
         val result = builder.build(property, parameterIndex)
 
         parameterBinders.addAll(result.binders)
         parameterIndex += result.paramCount
 
-        return result.condition
+        // 파라미터가 없는 조건(IS NULL 등)은 대소문자 구분이 의미 없습니다.
+        if (!ignoreCase || result.paramCount == 0) return result.condition
+
+        return result.condition.replace(PARAMETER_PLACEHOLDER) { "LOWER(${it.value})" }
+    }
+
+    /**
+     * `IgnoreCase` 키워드를 적용할지 결정합니다.
+     *
+     * `IgnoreCase`(ALWAYS)를 String이 아닌 프로퍼티에 쓰면 시작 시점에 실패시키고,
+     * `AllIgnoreCase`(WHEN_POSSIBLE)는 String 프로퍼티에만 적용합니다.
+     */
+    private fun shouldIgnoreCase(part: Part): Boolean {
+        val isStringProperty = part.property.leafProperty.type == String::class.java
+
+        return when (part.shouldIgnoreCase()) {
+            Part.IgnoreCaseType.ALWAYS -> {
+                if (!isStringProperty) {
+                    throw IllegalStateException(
+                        "IgnoreCase cannot be applied to non-String property " +
+                                "'${part.property.toDotPath()}' of type ${part.property.leafProperty.type.name}",
+                    )
+                }
+                true
+            }
+
+            Part.IgnoreCaseType.WHEN_POSSIBLE -> isStringProperty
+            else -> false
+        }
     }
 
     // ============================================

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod.kt
@@ -19,6 +19,7 @@ import java.lang.reflect.Method
  * @param isModifying @Modifying 어노테이션 사용 여부
  * @param parameterStyle 파라미터 바인딩 스타일 (NAMED, POSITIONAL, NONE)
  * @param parameterNames Named Parameter 사용 시 파라미터 이름 목록
+ * @param maxResults `Top`/`First` 키워드로 지정된 최대 결과 개수 (제한이 없으면 null)
  */
 public data class PreparedQueryMethod(
     val method: Method,
@@ -32,6 +33,7 @@ public data class PreparedQueryMethod(
     val isModifying: Boolean = false,
     val parameterStyle: ParameterStyle = ParameterStyle.NONE,
     val parameterNames: List<String> = emptyList(),
+    val maxResults: Int? = null,
 ) {
     internal val annotatedParameters: QueryParameters by lazy(LazyThreadSafetyMode.PUBLICATION) {
         QueryParameterParser.parse(hql)

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryAliasResolver.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/QueryAliasResolver.kt
@@ -1,0 +1,54 @@
+package io.clroot.hibernate.reactive.spring.boot.repository.query
+
+import java.util.Locale
+
+/**
+ * `@Query`로 선언된 HQL에서 루트 엔티티의 별칭을 찾아냅니다.
+ *
+ * 동적 `Sort`를 적용하려면 정렬 프로퍼티 앞에 붙일 별칭이 필요합니다.
+ * 별칭을 확신할 수 없으면 null을 반환하여 호출자가 정렬을 조용히 무시하는 대신
+ * 명확히 실패하도록 합니다.
+ */
+internal object QueryAliasResolver {
+
+    private const val IDENTIFIER = "[\\p{L}_$][\\p{L}\\p{N}_$]*"
+
+    /** `SELECT e FROM ...` / `SELECT DISTINCT e FROM ...` 형태의 단순 선택 별칭 */
+    private val SELECTED_ALIAS = Regex(
+        "^\\s*SELECT\\s+(?:DISTINCT\\s+)?($IDENTIFIER)\\s+FROM\\s",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** `FROM Entity e` / `FROM Entity AS e` 형태의 선언 별칭 */
+    private val DECLARED_ALIAS = Regex(
+        "\\bFROM\\s+$IDENTIFIER(?:\\.$IDENTIFIER)*\\s+(?:AS\\s+)?($IDENTIFIER)",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** 별칭 자리에 올 수 있지만 별칭이 아닌 예약어들 */
+    private val RESERVED_WORDS = setOf(
+        "WHERE", "ORDER", "GROUP", "HAVING", "JOIN", "LEFT", "RIGHT", "INNER", "OUTER", "FULL",
+        "CROSS", "ON", "UNION", "INTERSECT", "EXCEPT", "FETCH", "SET", "AS",
+    )
+
+    /**
+     * 루트 별칭을 반환합니다. 판별할 수 없으면 null을 반환합니다.
+     */
+    fun resolve(query: String): String? {
+        val normalizedQuery = query.trim()
+
+        SELECTED_ALIAS.find(normalizedQuery)
+            ?.groupValues
+            ?.get(1)
+            ?.takeIf(::isAlias)
+            ?.let { return it }
+
+        return DECLARED_ALIAS.find(normalizedQuery)
+            ?.groupValues
+            ?.get(1)
+            ?.takeIf(::isAlias)
+    }
+
+    private fun isAlias(candidate: String): Boolean =
+        candidate.uppercase(Locale.ROOT) !in RESERVED_WORDS
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/condition/LikeConditions.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/condition/LikeConditions.kt
@@ -24,10 +24,16 @@ internal data object NotLikeCondition : ConditionBuilder {
     )
 }
 
+/**
+ * StartingWith/EndingWith/Containing은 사용자 값을 패턴에 끼워 넣으므로
+ * 값 안의 `%`와 `_`를 이스케이프하고 `ESCAPE` 절을 함께 생성합니다.
+ * (명시적 `Like` 키워드는 사용자가 직접 패턴을 넘기는 것이므로 이스케이프하지 않습니다.)
+ */
+
 /** LIKE with prefix: value% */
 internal data object StartingWithCondition : ConditionBuilder {
     override fun build(property: String, paramIndex: Int) = ConditionResult(
-        condition = "$property LIKE :p$paramIndex",
+        condition = "$property LIKE :p$paramIndex${ParameterBinder.LIKE_ESCAPE_CLAUSE}",
         binders = listOf(ParameterBinder.StartingWith),
         paramCount = 1,
     )
@@ -36,7 +42,7 @@ internal data object StartingWithCondition : ConditionBuilder {
 /** LIKE with suffix: %value */
 internal data object EndingWithCondition : ConditionBuilder {
     override fun build(property: String, paramIndex: Int) = ConditionResult(
-        condition = "$property LIKE :p$paramIndex",
+        condition = "$property LIKE :p$paramIndex${ParameterBinder.LIKE_ESCAPE_CLAUSE}",
         binders = listOf(ParameterBinder.EndingWith),
         paramCount = 1,
     )
@@ -45,7 +51,7 @@ internal data object EndingWithCondition : ConditionBuilder {
 /** LIKE with both: %value% */
 internal data object ContainingCondition : ConditionBuilder {
     override fun build(property: String, paramIndex: Int) = ConditionResult(
-        condition = "$property LIKE :p$paramIndex",
+        condition = "$property LIKE :p$paramIndex${ParameterBinder.LIKE_ESCAPE_CLAUSE}",
         binders = listOf(ParameterBinder.Containing),
         paramCount = 1,
     )
@@ -54,7 +60,7 @@ internal data object ContainingCondition : ConditionBuilder {
 /** NOT LIKE with both: %value% */
 internal data object NotContainingCondition : ConditionBuilder {
     override fun build(property: String, paramIndex: Int) = ConditionResult(
-        condition = "$property NOT LIKE :p$paramIndex",
+        condition = "$property NOT LIKE :p$paramIndex${ParameterBinder.LIKE_ESCAPE_CLAUSE}",
         binders = listOf(ParameterBinder.Containing),
         paramCount = 1,
     )

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager.kt
@@ -17,6 +17,7 @@ import org.springframework.transaction.UnexpectedRollbackException
 import org.springframework.transaction.reactive.AbstractReactiveTransactionManager
 import org.springframework.transaction.reactive.GenericReactiveTransaction
 import org.springframework.transaction.reactive.TransactionSynchronizationManager
+import reactor.core.Disposables
 import reactor.core.publisher.Mono
 import kotlin.time.Duration.Companion.seconds
 
@@ -287,17 +288,35 @@ public class HibernateReactiveTransactionManager(
      */
     private fun <T : Any> runOnVertxContext(vertxContext: Context?, block: () -> Mono<T>): Mono<T> {
         if (vertxContext == null) {
-            return block()
+            return try {
+                block()
+            } catch (error: Throwable) {
+                Mono.error(error)
+            }
         }
 
         return Mono.create { sink ->
-            vertxContext.runOnContext {
-                block()
-                    .subscribe(
-                        { value -> sink.success(value) },
-                        { error -> sink.error(error) },
-                        { sink.success() },
-                    )
+            val subscription = Disposables.swap()
+            sink.onCancel(subscription)
+
+            // block()이 동기적으로 던지면 sink가 종료되지 않아 커밋/롤백이 영원히 대기하게 된다.
+            // 세션에서 ReactiveConnection을 꺼내는 리플렉션이 대표적인 동기 실패 지점이다.
+            try {
+                vertxContext.runOnContext {
+                    try {
+                        subscription.update(
+                            block().subscribe(
+                                { value -> sink.success(value) },
+                                { error -> sink.error(error) },
+                                { sink.success() },
+                            ),
+                        )
+                    } catch (error: Throwable) {
+                        sink.error(error)
+                    }
+                }
+            } catch (error: Throwable) {
+                sink.error(error)
             }
         }
     }

--- a/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/SpringAmbientTransactionProbe.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter-common/src/main/kotlin/io/clroot/hibernate/reactive/spring/boot/transaction/SpringAmbientTransactionProbe.kt
@@ -1,0 +1,49 @@
+package io.clroot.hibernate.reactive.spring.boot.transaction
+
+import io.clroot.hibernate.reactive.AmbientTransaction
+import io.clroot.hibernate.reactive.AmbientTransactionProbe
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.reactor.ReactorContext
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.hibernate.reactive.mutiny.Mutiny
+import org.springframework.transaction.NoTransactionException
+import org.springframework.transaction.reactive.TransactionSynchronizationManager
+
+/**
+ * Spring `@Transactional`이 시작한 리액티브 트랜잭션을 감지합니다.
+ *
+ * 이 훅이 없으면 `@Transactional` 안에서 `tx.transactional {}`을 호출할 때
+ * 별도의 세션과 트랜잭션이 열리지만, 정작 Repository 호출은
+ * [TransactionalAwareSessionProvider]를 통해 Spring 세션으로 향합니다.
+ */
+public class SpringAmbientTransactionProbe(
+    private val sessionFactory: Mutiny.SessionFactory,
+) : AmbientTransactionProbe {
+
+    override suspend fun currentTransaction(): AmbientTransaction? {
+        val reactorContext = currentCoroutineContext()[ReactorContext]?.context
+            ?: return null
+
+        return try {
+            TransactionSynchronizationManager.forCurrentTransaction()
+                .mapNotNull { synchronizationManager ->
+                    if (!synchronizationManager.isActualTransactionActive) {
+                        return@mapNotNull null
+                    }
+
+                    val holder = synchronizationManager.getResource(sessionFactory) as? MutinySessionHolder
+                        ?: return@mapNotNull null
+                    val sessionContext = holder.toReactiveSessionContext()
+
+                    AmbientTransaction(
+                        isReadOnly = sessionContext.isReadOnly,
+                        remainingTimeout = sessionContext.remainingTimeout(),
+                    )
+                }
+                .contextWrite(reactorContext)
+                .awaitSingleOrNull()
+        } catch (_: NoTransactionException) {
+            null
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/api/hibernate-reactive-coroutines-spring-boot-starter.api
+++ b/hibernate-reactive-coroutines-spring-boot-starter/api/hibernate-reactive-coroutines-spring-boot-starter.api
@@ -22,11 +22,12 @@ public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/AuditingAuto
 
 public class io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveAutoConfiguration {
 	public fun <init> (Lorg/springframework/context/ApplicationContext;Lio/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/lang/Integer;ZZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZ)V
+	public fun ambientTransactionProbe (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/AmbientTransactionProbe;
 	public fun hibernateReactiveTransactionManager (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/HibernateReactiveTransactionManager;
 	public fun hibernateSessionFactory ()Lorg/hibernate/SessionFactory;
 	public fun reactiveSessionFactory (Lorg/hibernate/SessionFactory;)Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;
 	public fun reactiveSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveSessionProvider;
-	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
+	public fun reactiveTransactionExecutor (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;Lio/clroot/hibernate/reactive/AmbientTransactionProbe;)Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;
 	public fun transactionalAwareSessionProvider (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;
 	public fun transactionalEventPublisher (Lorg/springframework/context/ApplicationEventPublisher;)Lorg/springframework/transaction/reactive/TransactionalEventPublisher;
 }
@@ -110,8 +111,8 @@ public final class io/clroot/hibernate/reactive/spring/boot/repository/Hibernate
 
 public final class io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository : java/lang/reflect/InvocationHandler {
 	public static final field Companion Lio/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepository$Companion;
-	public fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;)V
-	public synthetic fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Class;Ljava/lang/Class;Lio/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider;Lio/clroot/hibernate/reactive/ReactiveTransactionExecutor;Ljava/util/Map;Lio/clroot/hibernate/reactive/spring/boot/auditing/ReactiveAuditingHandler;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun invoke (Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -177,11 +178,12 @@ public final class io/clroot/hibernate/reactive/spring/boot/repository/query/Par
 }
 
 public final class io/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod {
-	public fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/reflect/Method;
 	public final fun component10 ()Lio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;
 	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/Integer;
 	public final fun component2 ()Lorg/springframework/data/repository/query/parser/PartTree;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -190,11 +192,12 @@ public final class io/clroot/hibernate/reactive/spring/boot/repository/query/Pre
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
-	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public final fun copy (Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
+	public static synthetic fun copy$default (Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;Ljava/lang/reflect/Method;Lorg/springframework/data/repository/query/parser/PartTree;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/clroot/hibernate/reactive/spring/boot/repository/query/QueryReturnType;ZZZLio/clroot/hibernate/reactive/spring/boot/repository/query/ParameterStyle;Ljava/util/List;Ljava/lang/Integer;ILjava/lang/Object;)Lio/clroot/hibernate/reactive/spring/boot/repository/query/PreparedQueryMethod;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCountHql ()Ljava/lang/String;
 	public final fun getHql ()Ljava/lang/String;
+	public final fun getMaxResults ()Ljava/lang/Integer;
 	public final fun getMethod ()Ljava/lang/reflect/Method;
 	public final fun getParameterBinders ()Ljava/util/List;
 	public final fun getParameterNames ()Ljava/util/List;
@@ -247,6 +250,11 @@ public final class io/clroot/hibernate/reactive/spring/boot/transaction/MutinySe
 	public final fun setTransactionActive (Z)V
 	public final fun setVertxContext (Lio/vertx/core/Context;)V
 	public final fun toReactiveSessionContext ()Lio/clroot/hibernate/reactive/ReactiveSessionContext;
+}
+
+public final class io/clroot/hibernate/reactive/spring/boot/transaction/SpringAmbientTransactionProbe : io/clroot/hibernate/reactive/AmbientTransactionProbe {
+	public fun <init> (Lorg/hibernate/reactive/mutiny/Mutiny$SessionFactory;)V
+	public fun currentTransaction (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/clroot/hibernate/reactive/spring/boot/transaction/TransactionalAwareSessionProvider {

--- a/hibernate-reactive-coroutines-spring-boot-starter/build.gradle.kts
+++ b/hibernate-reactive-coroutines-spring-boot-starter/build.gradle.kts
@@ -34,10 +34,6 @@ dependencies {
     // Mutiny-Reactor (for Uni/Mono conversion)
     implementation(libs.mutiny.reactor)
 
-    // Spring Boot annotation processor
-    annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:3.4.13"))
-    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(libs.kotest.runner.junit5)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadataTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/auditing/AuditMetadataTest.kt
@@ -1,0 +1,79 @@
+package io.clroot.hibernate.reactive.spring.boot.auditing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+
+/**
+ * auditing 타임스탬프 처리를 검증합니다.
+ */
+class AuditMetadataTest : DescribeSpec({
+
+    describe("지원 시간 타입") {
+
+        it("OffsetDateTime 필드를 채운다") {
+            val entity = OffsetDateTimeEntity()
+
+            AuditMetadata.setCreatedDate(entity)
+            AuditMetadata.setLastModifiedDate(entity)
+
+            entity.createdAt.shouldNotBeNull()
+            entity.updatedAt.shouldNotBeNull()
+        }
+
+        it("ZonedDateTime 필드를 채운다") {
+            val entity = ZonedDateTimeEntity()
+
+            AuditMetadata.setCreatedDate(entity)
+
+            entity.createdAt.shouldNotBeNull()
+        }
+    }
+
+    describe("생성 시각") {
+
+        it("같은 기준 시각을 넘기면 생성/수정 시각이 동일하다") {
+            val entity = OffsetDateTimeEntity()
+            val now = Instant.now()
+
+            AuditMetadata.setCreatedDate(entity, now)
+            AuditMetadata.setLastModifiedDate(entity, now)
+
+            entity.createdAt!!.toInstant() shouldBe entity.updatedAt!!.toInstant()
+        }
+    }
+
+    describe("지원하지 않는 타입") {
+
+        it("필드를 건드리지 않는다") {
+            val entity = UnsupportedTypeEntity()
+
+            AuditMetadata.setCreatedDate(entity)
+
+            entity.createdAt shouldBe null
+        }
+    }
+})
+
+private class OffsetDateTimeEntity {
+    @CreatedDate
+    var createdAt: OffsetDateTime? = null
+
+    @LastModifiedDate
+    var updatedAt: OffsetDateTime? = null
+}
+
+private class ZonedDateTimeEntity {
+    @CreatedDate
+    var createdAt: ZonedDateTime? = null
+}
+
+private class UnsupportedTypeEntity {
+    @CreatedDate
+    var createdAt: StringBuilder? = null
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveTransactionManagerAutoConfigurationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/autoconfigure/HibernateReactiveTransactionManagerAutoConfigurationTest.kt
@@ -1,0 +1,82 @@
+package io.clroot.hibernate.reactive.spring.boot.autoconfigure
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.mockk
+import org.hibernate.SessionFactory
+import org.hibernate.reactive.mutiny.Mutiny
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.transaction.ReactiveTransactionManager
+
+class HibernateReactiveTransactionManagerAutoConfigurationTest : DescribeSpec({
+    describe("Hibernate Reactive transaction manager auto-configuration") {
+        it("backs off when another ReactiveTransactionManager exists") {
+            contextRunner()
+                .withBean(
+                    "r2dbcTransactionManager",
+                    ReactiveTransactionManager::class.java,
+                    { mockk<ReactiveTransactionManager>() },
+                )
+                .run { context ->
+                    context.getBeanNamesForType(ReactiveTransactionManager::class.java).toList() shouldContainExactly
+                            listOf("r2dbcTransactionManager")
+                }
+        }
+
+        it("registers its own transaction manager when none exists") {
+            contextRunner().run { context ->
+                context.getBeanNamesForType(ReactiveTransactionManager::class.java).toList() shouldContainExactly
+                        listOf("hibernateReactiveTransactionManager")
+            }
+        }
+    }
+
+    describe("session factory auto-configuration") {
+        it("does not build a second session factory when the user supplies a Mutiny.SessionFactory") {
+            ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+                .withBean("userSessionFactory", Mutiny.SessionFactory::class.java, { mockk<Mutiny.SessionFactory>() })
+                .run { context ->
+                    context.getBeanNamesForType(Mutiny.SessionFactory::class.java).toList() shouldContainExactly
+                            listOf("userSessionFactory")
+                    context.containsBean("hibernateSessionFactory") shouldBe false
+                }
+        }
+
+        it("starts without spring.datasource.url when the user supplies a Mutiny.SessionFactory") {
+            ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+                .withBean("userSessionFactory", Mutiny.SessionFactory::class.java, { mockk<Mutiny.SessionFactory>() })
+                .run { context ->
+                    context.startupFailure shouldBe null
+                }
+        }
+
+        it("fails with an actionable message when spring.datasource.url is missing") {
+            // Testcontainers 픽스처가 JVM 시스템 프로퍼티를 설정하므로 빈 값으로 덮어씁니다.
+            ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+                .withPropertyValues("spring.datasource.url=")
+                .run { context ->
+                    val failure = context.startupFailure.shouldNotBeNull()
+                    failure.stackTraceToString() shouldContain "spring.datasource.url"
+                }
+        }
+    }
+})
+
+private fun contextRunner(): ApplicationContextRunner =
+    ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(HibernateReactiveAutoConfiguration::class.java))
+        .withBean("hibernateSessionFactory", SessionFactory::class.java, { mockk<SessionFactory>() })
+        .withBean("reactiveSessionFactory", Mutiny.SessionFactory::class.java, { mockk<Mutiny.SessionFactory>() })
+        .withPropertyValues(
+            "spring.datasource.url=jdbc:postgresql://localhost/test",
+            "spring.datasource.username=test",
+            "spring.datasource.password=test",
+            "spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect",
+        )

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBeanTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/HibernateReactiveRepositoryFactoryBeanTest.kt
@@ -6,13 +6,25 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
 import io.mockk.mockk
+import jakarta.persistence.metamodel.EntityType
+import jakarta.persistence.metamodel.Metamodel
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 
 class HibernateReactiveRepositoryFactoryBeanTest : DescribeSpec({
 
     val sessionProvider = mockk<TransactionalAwareSessionProvider>()
     val transactionExecutor = mockk<ReactiveTransactionExecutor>()
+
+    // HQL 엔티티 이름은 JPA 메타모델에서 조회하므로 테스트에서도 등록된 엔티티처럼 동작시킵니다.
+    val metamodel = mockk<Metamodel>()
+    every { sessionProvider.metamodel } returns metamodel
+    every { metamodel.entity(any<Class<*>>()) } answers {
+        mockk<EntityType<*>> {
+            every { name } returns firstArg<Class<*>>().simpleName
+        }
+    }
 
     describe("HibernateReactiveRepositoryFactoryBean") {
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodParserTest.kt
@@ -202,10 +202,10 @@ private interface QueryRepository {
     suspend fun findWithRolesAndCount(pageable: Pageable): Page<User>
 
     @Query(
-        value = "SELECT e.active FROM User e GROUP BY e.active",
+        value = "SELECT e FROM User e GROUP BY e",
         countQuery = "SELECT COUNT(DISTINCT e.active) FROM User e",
     )
-    suspend fun countByActiveWithCount(pageable: Pageable): Page<Boolean>
+    suspend fun countByActiveWithCount(pageable: Pageable): Page<User>
 
     @Query(
         value = "SELECT e FROM User e WHERE e.active = :active " +

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodValidationTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/QueryMethodValidationTest.kt
@@ -1,0 +1,120 @@
+package io.clroot.hibernate.reactive.spring.boot.repository
+
+import io.clroot.hibernate.reactive.spring.boot.repository.query.PartTreeHqlBuilder
+import io.clroot.hibernate.reactive.spring.boot.repository.query.Query
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.springframework.data.repository.query.parser.PartTree
+
+/**
+ * 예전에는 시작 시점을 통과한 뒤 런타임에 조용히 오동작하던 선언들이
+ * 이제 명확한 메시지로 거부되는지 검증합니다.
+ */
+class QueryMethodValidationTest : DescribeSpec({
+    val parser = QueryMethodParser(Member::class.java)
+
+    fun parse(methodName: String) = parser.parse(
+        MemberRepository::class.java.methods.single { it.name == methodName },
+    )
+
+    describe("IgnoreCase") {
+        it("compares both sides in lower case") {
+            val partTree = PartTree("findByName", Member::class.java)
+            PartTreeHqlBuilder("Member", PartTree("findByNameIgnoreCase", Member::class.java))
+                .build()
+                .hql shouldBe "FROM Member e WHERE LOWER(e.name) = LOWER(:p0)"
+
+            // 대조군: IgnoreCase가 없으면 그대로 비교합니다.
+            PartTreeHqlBuilder("Member", partTree).build().hql shouldBe
+                    "FROM Member e WHERE e.name = :p0"
+        }
+
+        it("applies to LIKE conditions as well") {
+            PartTreeHqlBuilder("Member", PartTree("findByNameContainingIgnoreCase", Member::class.java))
+                .build()
+                .hql shouldBe "FROM Member e WHERE LOWER(e.name) LIKE LOWER(:p0) ESCAPE '\\'"
+        }
+
+        it("rejects IgnoreCase on a non-String property") {
+            val error = shouldThrow<IllegalStateException> {
+                PartTreeHqlBuilder("Member", PartTree("findByAgeIgnoreCase", Member::class.java)).build()
+            }
+
+            error.message shouldContain "non-String property"
+        }
+    }
+
+    describe("Distinct") {
+        it("emits SELECT DISTINCT") {
+            PartTreeHqlBuilder("Member", PartTree("findDistinctByName", Member::class.java))
+                .build()
+                .hql shouldBe "SELECT DISTINCT e FROM Member e WHERE e.name = :p0"
+        }
+    }
+
+    describe("Top/First limiting") {
+        it("captures the declared limit") {
+            parse("findTop3ByOrderByAgeDesc").maxResults shouldBe 3
+            parse("findFirstByOrderByAgeDesc").maxResults shouldBe 1
+            parse("findByName").maxResults shouldBe null
+        }
+
+        it("rejects combining a limit with Pageable") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findTop3ByName")
+            }
+
+            error.message shouldContain "ambiguous"
+        }
+    }
+
+    describe("derived query parameters") {
+        it("rejects a method whose name needs more arguments than it declares") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("findByNameAndAge")
+            }
+
+            error.message shouldContain "derives 2 query parameter(s)"
+        }
+    }
+
+    describe("@Query result types") {
+        it("rejects scalar projections") {
+            val error = shouldThrow<IllegalStateException> {
+                parse("sumAges")
+            }
+
+            error.message shouldContain "only the entity type Member"
+        }
+
+        it("accepts entity results") {
+            parse("findActive").hql shouldContain "FROM Member"
+        }
+    }
+})
+
+private class Member(
+    val id: Long,
+    val name: String,
+    val age: Int,
+)
+
+private interface MemberRepository {
+    suspend fun findByName(name: String): Member?
+
+    suspend fun findTop3ByOrderByAgeDesc(): List<Member>
+
+    suspend fun findFirstByOrderByAgeDesc(): Member?
+
+    suspend fun findTop3ByName(name: String, pageable: org.springframework.data.domain.Pageable): List<Member>
+
+    suspend fun findByNameAndAge(name: String): Member?
+
+    @Query("SELECT SUM(e.age) FROM Member e")
+    suspend fun sumAges(): Long
+
+    @Query("SELECT e FROM Member e WHERE e.age > 0")
+    suspend fun findActive(): List<Member>
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/SimpleHibernateReactiveRepositoryTest.kt
@@ -214,6 +214,7 @@ class SimpleHibernateReactiveRepositoryTest : DescribeSpec({
 
                 val crud = CrudOperations<SaveAllEntity, Long>(
                     entityClass = SaveAllEntity::class.java,
+                    entityName = "SaveAllEntity",
                     sessionProvider = localSessionProvider,
                     transactionExecutor = localTransactionExecutor,
                     auditingHandler = null,

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PartTreeHqlBuilderTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/spring/boot/repository/query/PartTreeHqlBuilderTest.kt
@@ -83,7 +83,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders shouldHaveSize 1
                 result.parameterBinders[0] shouldBe ParameterBinder.Containing
             }
@@ -94,7 +94,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders shouldHaveSize 1
                 result.parameterBinders[0] shouldBe ParameterBinder.StartingWith
             }
@@ -105,7 +105,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders shouldHaveSize 1
                 result.parameterBinders[0] shouldBe ParameterBinder.EndingWith
             }
@@ -116,7 +116,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "FROM User e WHERE e.name NOT LIKE :p0"
+                result.hql shouldBe "FROM User e WHERE e.name NOT LIKE :p0 ESCAPE '\\'"
                 result.parameterBinders[0] shouldBe ParameterBinder.Containing
             }
         }
@@ -335,7 +335,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "DELETE FROM User e WHERE e.name = :p0"
+                result.hql shouldBe "FROM User e WHERE e.name = :p0"
             }
 
             it("deleteByAge") {
@@ -344,7 +344,7 @@ class PartTreeHqlBuilderTest : DescribeSpec({
 
                 val result = builder.build()
 
-                result.hql shouldBe "DELETE FROM User e WHERE e.age = :p0"
+                result.hql shouldBe "FROM User e WHERE e.age = :p0"
             }
         }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/AnnotatedQuerySortTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/AnnotatedQuerySortTest.kt
@@ -1,0 +1,80 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.TestEntity
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.kotest.matchers.collections.shouldContainExactly
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+/**
+ * `@Query` 메서드에도 동적 정렬이 적용되는지 검증합니다.
+ *
+ * 정렬이 무시되면 페이징 결과 순서가 보장되지 않아 페이지 간 중복·누락이 발생합니다.
+ */
+@SpringBootTest
+class AnnotatedQuerySortTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    init {
+        beforeEach {
+            tx.transactional {
+                testEntityRepository.save(TestEntity(name = "b", value = 10))
+                testEntityRepository.save(TestEntity(name = "a", value = 20))
+                testEntityRepository.save(TestEntity(name = "c", value = 30))
+            }
+        }
+
+        describe("@Query + Sort 파라미터") {
+
+            it("Sort를 적용한다") {
+                val sorted = tx.readOnly {
+                    testEntityRepository.findByValueGreaterThanWithQuery(0, Sort.by("name"))
+                }
+
+                sorted.map { it.name } shouldContainExactly listOf("a", "b", "c")
+            }
+
+            it("쿼리에 이미 있는 ORDER BY를 보존하고 뒤에 덧붙인다") {
+                val sorted = tx.readOnly {
+                    testEntityRepository.findOrderedByValueGreaterThanWithQuery(0, Sort.by("name"))
+                }
+
+                // 쿼리의 value DESC가 우선 적용됩니다.
+                sorted.map { it.name } shouldContainExactly listOf("c", "a", "b")
+            }
+        }
+
+        describe("@Query + 정렬된 Pageable") {
+
+            it("Page 조회에 Pageable의 Sort를 적용한다") {
+                val page = tx.readOnly {
+                    testEntityRepository.findByValueWithQueryPageable(
+                        10,
+                        PageRequest.of(0, 10, Sort.by("name")),
+                    )
+                }
+
+                page.content.map { it.name } shouldContainExactly listOf("b")
+            }
+
+            it("Slice 조회에 Pageable의 Sort를 적용한다") {
+                val slice = tx.readOnly {
+                    testEntityRepository.findByValueGreaterThanWithQuerySlice(
+                        0,
+                        PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "name")),
+                    )
+                }
+
+                slice.content.map { it.name } shouldContainExactly listOf("c", "b")
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/DeleteSemanticsAndLimitTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/DeleteSemanticsAndLimitTest.kt
@@ -1,0 +1,142 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.ChildEntity
+import io.clroot.hibernate.reactive.test.entity.ParentEntity
+import io.clroot.hibernate.reactive.test.entity.TestEntity
+import io.clroot.hibernate.reactive.test.repository.ChildEntityRepository
+import io.clroot.hibernate.reactive.test.repository.ParentEntityRepository
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * 삭제 의미론과 결과 개수 제한 동작을 검증합니다.
+ *
+ * bulk `DELETE` 문은 cascade와 영속성 컨텍스트를 건너뛰므로, 로드 후 제거 방식으로
+ * 동작하는지 실제 DB에 대해 확인합니다.
+ */
+@SpringBootTest
+class DeleteSemanticsAndLimitTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    @Autowired
+    private lateinit var parentEntityRepository: ParentEntityRepository
+
+    @Autowired
+    private lateinit var childEntityRepository: ChildEntityRepository
+
+    init {
+        describe("deleteById") {
+
+            it("자식까지 cascade 삭제한다") {
+                val parentId = tx.transactional {
+                    val parent = ParentEntity(name = "parent")
+                    parent.addChild(ChildEntity(name = "child-1"))
+                    parent.addChild(ChildEntity(name = "child-2"))
+                    parentEntityRepository.save(parent).id!!
+                }
+
+                tx.transactional {
+                    parentEntityRepository.deleteById(parentId)
+                }
+
+                tx.readOnly {
+                    parentEntityRepository.findById(parentId) shouldBe null
+                }
+                countChildRows() shouldBe 0L
+            }
+
+            it("존재하지 않는 ID는 조용히 무시한다") {
+                tx.transactional {
+                    testEntityRepository.deleteById(-1L)
+                }
+            }
+
+            it("같은 트랜잭션 안에서 삭제한 엔티티는 다시 조회되지 않는다") {
+                val id = tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "gone", value = 1)).id!!
+                }
+
+                tx.transactional {
+                    testEntityRepository.deleteById(id)
+                    testEntityRepository.findById(id) shouldBe null
+                }
+            }
+        }
+
+        describe("deleteAll") {
+
+            it("자식까지 cascade 삭제한다") {
+                tx.transactional {
+                    val parent = ParentEntity(name = "parent")
+                    parent.addChild(ChildEntity(name = "child-1"))
+                    parentEntityRepository.save(parent)
+                }
+
+                tx.transactional {
+                    parentEntityRepository.deleteAll()
+                }
+
+                tx.readOnly {
+                    parentEntityRepository.count() shouldBe 0L
+                }
+                countChildRows() shouldBe 0L
+            }
+        }
+
+        describe("파생 deleteBy 메서드") {
+
+            it("삭제 건수를 반환한다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "a", value = 7))
+                    testEntityRepository.save(TestEntity(name = "b", value = 7))
+                    testEntityRepository.save(TestEntity(name = "c", value = 8))
+                }
+
+                val deleted = tx.transactional {
+                    testEntityRepository.deleteAllByValue(7)
+                }
+
+                deleted shouldBe 2L
+                tx.readOnly { testEntityRepository.count() } shouldBe 1L
+            }
+        }
+
+        describe("Top/First 개수 제한") {
+
+            it("findTop2By는 상위 2건만 반환한다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "low", value = 1))
+                    testEntityRepository.save(TestEntity(name = "mid", value = 5))
+                    testEntityRepository.save(TestEntity(name = "high", value = 9))
+                }
+
+                val top = tx.readOnly { testEntityRepository.findTop2ByOrderByValueDesc() }
+
+                top.map { it.name } shouldContainExactly listOf("high", "mid")
+            }
+
+            it("findFirstBy는 여러 건이 매칭돼도 예외 없이 첫 건을 반환한다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "low", value = 1))
+                    testEntityRepository.save(TestEntity(name = "high", value = 9))
+                }
+
+                val first = tx.readOnly { testEntityRepository.findFirstByOrderByValueDesc() }
+
+                first.shouldNotBeNull().name shouldBe "high"
+            }
+        }
+    }
+
+    private suspend fun countChildRows(): Long = tx.readOnly { childEntityRepository.count() }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/EntityNamingAndLikeEscapingTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/EntityNamingAndLikeEscapingTest.kt
@@ -1,0 +1,85 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.test.entity.RenamedEntity
+import io.clroot.hibernate.reactive.test.entity.TestEntity
+import io.clroot.hibernate.reactive.test.repository.RenamedEntityRepository
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * 엔티티 이름 해석과 LIKE 와일드카드 이스케이프를 실제 DB에 대해 검증합니다.
+ */
+@SpringBootTest
+class EntityNamingAndLikeEscapingTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var renamedEntityRepository: RenamedEntityRepository
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    init {
+        describe("@Entity(name = ...)로 이름을 바꾼 엔티티") {
+
+            it("기본 CRUD가 동작한다") {
+                val saved = tx.transactional {
+                    renamedEntityRepository.save(RenamedEntity(name = "renamed"))
+                }
+
+                tx.readOnly {
+                    renamedEntityRepository.findById(saved.id!!).shouldNotBeNull().name shouldBe "renamed"
+                    renamedEntityRepository.count() shouldBe 1L
+                }
+            }
+
+            it("파생 쿼리가 동작한다") {
+                tx.transactional {
+                    renamedEntityRepository.save(RenamedEntity(name = "target"))
+                    renamedEntityRepository.save(RenamedEntity(name = "other"))
+                }
+
+                tx.readOnly {
+                    renamedEntityRepository.findByName("target").shouldNotBeNull()
+                }
+
+                val deleted = tx.transactional { renamedEntityRepository.deleteByName("target") }
+
+                deleted shouldBe 1L
+                tx.readOnly { renamedEntityRepository.count() } shouldBe 1L
+            }
+        }
+
+        describe("LIKE 와일드카드 이스케이프") {
+
+            it("Containing에 %를 넘겨도 전체 행이 매칭되지 않는다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "plain", value = 1))
+                    testEntityRepository.save(TestEntity(name = "100% cotton", value = 2))
+                }
+
+                val matched = tx.readOnly { testEntityRepository.findAllByNameContaining("%") }
+
+                matched.map { it.name } shouldContainExactlyInAnyOrder listOf("100% cotton")
+            }
+
+            it("Containing의 _는 임의의 한 글자가 아니라 밑줄 자체로 매칭된다") {
+                tx.transactional {
+                    testEntityRepository.save(TestEntity(name = "a_b", value = 1))
+                    testEntityRepository.save(TestEntity(name = "axb", value = 2))
+                }
+
+                val matched = tx.readOnly { testEntityRepository.findAllByNameContaining("a_b") }
+
+                matched.map { it.name } shouldContainExactlyInAnyOrder listOf("a_b")
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/HqlRecorderTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/HqlRecorderTest.kt
@@ -98,7 +98,7 @@ class HqlRecorderTest : RecordingIntegrationTestBase() {
 
             context("DELETE 쿼리 기록") {
 
-                it("deleteByName은 DELETE HQL을 생성한다") {
+                it("deleteByName은 대상을 조회한 뒤 제거한다") {
                     // given
                     tx.transactional {
                         testEntityRepository.save(TestEntity(name = "to-delete", value = 1))
@@ -111,9 +111,10 @@ class HqlRecorderTest : RecordingIntegrationTestBase() {
                     }
 
                     // then
+                    // cascade와 @Version이 동작하도록 bulk DELETE 대신 로드 후 제거합니다.
                     hqlRecorder.assertQueryCount(1)
-                    hqlRecorder.assertLastQueryContains("DELETE FROM TestEntity")
-                    hqlRecorder.getLastQuery()?.queryType shouldBe QueryType.DELETE
+                    hqlRecorder.assertLastQueryContains("FROM TestEntity")
+                    hqlRecorder.getLastQuery()?.queryType shouldBe QueryType.SELECT
                 }
             }
 

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/MixedTransactionModelTest.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/test/kotlin/io/clroot/hibernate/reactive/test/MixedTransactionModelTest.kt
@@ -1,0 +1,56 @@
+package io.clroot.hibernate.reactive.test
+
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.ReadOnlyTransactionException
+import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
+import io.clroot.hibernate.reactive.test.service.TransactionalTestService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+
+/**
+ * Spring `@Transactional`과 `tx.transactional {}`을 함께 쓸 때의 동작을 검증합니다.
+ *
+ * `tx.transactional`이 바깥 Spring 트랜잭션을 감지하지 못하면 별도 세션과 트랜잭션이 열려
+ * 롤백 경계가 어긋납니다.
+ */
+@SpringBootTest(classes = [TestApplication::class, TransactionalTestService::class])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+class MixedTransactionModelTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var testService: TransactionalTestService
+
+    @Autowired
+    private lateinit var tx: ReactiveTransactionExecutor
+
+    @Autowired
+    private lateinit var testEntityRepository: TestEntityRepository
+
+    init {
+        describe("@Transactional 안의 tx.transactional") {
+
+            it("중복 세션을 열지 않는다") {
+                testService.opensRedundantSession() shouldBe false
+            }
+
+            it("바깥 트랜잭션에 참여하여 함께 롤백된다") {
+                shouldThrow<RuntimeException> {
+                    testService.saveNestedAndFail("nested-rollback", 1)
+                }
+
+                tx.readOnly { testEntityRepository.count() } shouldBe 0L
+            }
+
+            it("읽기 전용 트랜잭션을 쓰기로 승격하지 못한다") {
+                shouldThrow<ReadOnlyTransactionException> {
+                    testService.upgradeReadOnlyTransaction("should-not-persist")
+                }
+
+                tx.readOnly { testEntityRepository.count() } shouldBe 0L
+            }
+        }
+    }
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/IntegrationTestBase.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/IntegrationTestBase.kt
@@ -3,6 +3,7 @@ package io.clroot.hibernate.reactive.test
 import io.clroot.hibernate.reactive.spring.boot.autoconfigure.HibernateReactiveAutoConfiguration
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
+import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny
 import org.springframework.beans.factory.annotation.Autowired
@@ -60,13 +61,26 @@ abstract class IntegrationTestBase : DescribeSpec() {
      * FK 제약조건 순서를 고려하여 자식 테이블부터 삭제합니다.
      */
     private suspend fun clearAllTables() {
+        // FK 제약조건 순서: 자식 → 부모
+        val entityNames = listOf(
+            "ChildEntity",
+            "ParentEntity",
+            "VersionedEntity",
+            "AnotherEntity",
+            "RenamedAlias",
+            "TestEntity",
+        )
+
         sessionFactory.withTransaction { session ->
-            // FK 제약조건 순서: 자식 → 부모
-            session.createMutationQuery("DELETE FROM ChildEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM ParentEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM VersionedEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM AnotherEntity").executeUpdate()
-            session.createMutationQuery("DELETE FROM TestEntity").executeUpdate()
+            // Uni는 구독해야 실행되므로 반드시 chain으로 연결한다.
+            // 나열만 하면 마지막 구문 외에는 실행되지 않는다.
+            entityNames.fold(Uni.createFrom().voidItem()) { chain, entityName ->
+                chain.chain { _ ->
+                    session.createMutationQuery("DELETE FROM $entityName")
+                        .executeUpdate()
+                        .replaceWithVoid()
+                }
+            }
         }.awaitSuspending()
     }
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/RenamedEntity.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/entity/RenamedEntity.kt
@@ -1,0 +1,24 @@
+package io.clroot.hibernate.reactive.test.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+/**
+ * HQL 엔티티 이름이 클래스 단순 이름과 다른 엔티티.
+ *
+ * 엔티티 이름을 클래스 이름에서 유추하면 이 엔티티를 대상으로 한 모든 쿼리가 실패합니다.
+ */
+@Entity(name = "RenamedAlias")
+@Table(name = "renamed_entity")
+class RenamedEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    var name: String = "",
+)

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ChildEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/ChildEntityRepository.kt
@@ -1,0 +1,9 @@
+package io.clroot.hibernate.reactive.test.repository
+
+import io.clroot.hibernate.reactive.test.entity.ChildEntity
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+/**
+ * cascade 삭제 검증용 Repository.
+ */
+interface ChildEntityRepository : CoroutineCrudRepository<ChildEntity, Long>

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/RenamedEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/RenamedEntityRepository.kt
@@ -1,0 +1,14 @@
+package io.clroot.hibernate.reactive.test.repository
+
+import io.clroot.hibernate.reactive.test.entity.RenamedEntity
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+/**
+ * `@Entity(name = ...)`로 이름을 바꾼 엔티티용 Repository.
+ */
+interface RenamedEntityRepository : CoroutineCrudRepository<RenamedEntity, Long> {
+
+    suspend fun findByName(name: String): RenamedEntity?
+
+    suspend fun deleteByName(name: String): Long
+}

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/repository/TestEntityRepository.kt
@@ -32,6 +32,14 @@ interface TestEntityRepository : CoroutineCrudRepository<TestEntity, Long> {
     // 삭제
     suspend fun deleteByName(name: String)
 
+    // 삭제 건수 반환
+    suspend fun deleteAllByValue(value: Int): Long
+
+    // 개수 제한 (Top/First)
+    suspend fun findTop2ByOrderByValueDesc(): List<TestEntity>
+
+    suspend fun findFirstByOrderByValueDesc(): TestEntity?
+
     // LIKE 검색 (Containing)
     suspend fun findAllByNameContaining(name: String): List<TestEntity>
 
@@ -105,4 +113,18 @@ interface TestEntityRepository : CoroutineCrudRepository<TestEntity, Long> {
         countQuery = "SELECT COUNT(e) FROM TestEntity e WHERE e.value = :value",
     )
     suspend fun findByValueWithExplicitCount(@Param("value") value: Int, pageable: Pageable): Page<TestEntity>
+
+    // @Query + 동적 Sort
+    @Query("SELECT e FROM TestEntity e WHERE e.value > :minValue")
+    suspend fun findByValueGreaterThanWithQuery(
+        @Param("minValue") minValue: Int,
+        sort: Sort,
+    ): List<TestEntity>
+
+    // @Query에 ORDER BY가 이미 있는 경우
+    @Query("SELECT e FROM TestEntity e WHERE e.value > :minValue ORDER BY e.value DESC")
+    suspend fun findOrderedByValueGreaterThanWithQuery(
+        @Param("minValue") minValue: Int,
+        sort: Sort,
+    ): List<TestEntity>
 }

--- a/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/TransactionalTestService.kt
+++ b/hibernate-reactive-coroutines-spring-boot-starter/src/testFixtures/kotlin/io/clroot/hibernate/reactive/test/service/TransactionalTestService.kt
@@ -1,5 +1,8 @@
 package io.clroot.hibernate.reactive.test.service
 
+import io.clroot.hibernate.reactive.ReactiveSessionContext
+import io.clroot.hibernate.reactive.ReactiveTransactionExecutor
+import io.clroot.hibernate.reactive.currentSessionOrNull
 import io.clroot.hibernate.reactive.test.entity.TestEntity
 import io.clroot.hibernate.reactive.test.repository.TestEntityRepository
 import org.springframework.stereotype.Service
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class TransactionalTestService(
     private val testEntityRepository: TestEntityRepository,
+    private val transactionExecutor: ReactiveTransactionExecutor,
 ) {
     @Transactional
     suspend fun saveEntity(name: String, value: Int): TestEntity {
@@ -59,5 +63,41 @@ class TransactionalTestService(
         }
         onSaved(savedEntities.map { it.id!! })
         throw RuntimeException("의도적 롤백 - 모든 저장이 롤백되어야 함")
+    }
+
+    // === @Transactional 안에서 tx.transactional {} 을 함께 쓰는 경우 ===
+
+    /**
+     * `tx.transactional {}`이 바깥 `@Transactional`에 참여해야 합니다.
+     * 별도 트랜잭션이 열리면 이 저장은 롤백되지 않습니다.
+     */
+    @Transactional
+    suspend fun saveNestedAndFail(name: String, value: Int) {
+        transactionExecutor.transactional {
+            testEntityRepository.save(TestEntity(name = name, value = value))
+        }
+        throw RuntimeException("의도적 롤백 - 중첩 저장까지 롤백되어야 함")
+    }
+
+    /**
+     * `tx.transactional {}`이 바깥 Spring 트랜잭션을 감지했는지 확인합니다.
+     *
+     * 감지하지 못하면 새 세션을 열면서 [ReactiveSessionContext]를 코루틴 컨텍스트에 추가합니다.
+     * 즉 여기서 세션이 보인다면 쓰이지도 않을 세션이 하나 더 열렸다는 뜻입니다.
+     */
+    @Transactional
+    suspend fun opensRedundantSession(): Boolean =
+        transactionExecutor.transactional {
+            currentSessionOrNull() != null
+        }
+
+    /**
+     * 읽기 전용 `@Transactional` 안에서는 쓰기 트랜잭션으로 승격할 수 없습니다.
+     */
+    @Transactional(readOnly = true)
+    suspend fun upgradeReadOnlyTransaction(name: String) {
+        transactionExecutor.transactional {
+            testEntityRepository.save(TestEntity(name = name, value = 0))
+        }
     }
 }


### PR DESCRIPTION
## 배경

프로덕션 도입 관점의 코드 리뷰에서 나온 결함들을 우선순위대로 수정했습니다. 대부분은 **기동은 정상적으로 되고 런타임에 조용히 잘못된 결과를 반환하는** 부류라, 프로덕션에서 가장 발견하기 어려운 실패 모드입니다.

## 변경 내용

### 쿼리 파생

- **`Top`/`First` 제한 적용.** 파싱은 되지만 버려지고 있었습니다. `findTop3By…`는 전체 테이블을 메모리에 로드했고, `findFirstBy…`는 2건 이상 매칭 시 `NonUniqueResultException`을 던졌습니다.
- **`IgnoreCase`·`Distinct` 구현.** 두 키워드 모두 조용히 무시되어 대소문자를 구분해 비교하고 있었습니다. 이제 양쪽을 `LOWER()`로 비교하고 `SELECT DISTINCT`를 생성합니다.
- **LIKE 와일드카드 이스케이프.** `Containing`/`StartingWith`/`EndingWith`가 사용자 값을 그대로 패턴에 끼워 넣어, `findByNameContaining("%")`가 전체 행을 반환하는 필터 우회가 가능했습니다. 명시적 `Like` 키워드는 사용자가 패턴을 직접 넘기는 것이므로 이스케이프하지 않습니다.
- **엔티티 이름을 JPA 메타모델에서 조회.** 클래스 단순 이름으로 HQL을 만들고 있어 `@Entity(name = "…")`이나 패키지가 다른 동명 엔티티에서 런타임 오류가 났습니다.
- **`@Query` 메서드에 `Sort` 적용.** `Sort` 파라미터와 정렬이 담긴 `Pageable`이 무시되어 페이징 순서가 보장되지 않았습니다(페이지 간 중복·누락). 쿼리에 이미 있는 `ORDER BY` 뒤에 덧붙이므로 작성자의 정렬 의도가 우선합니다.
- **실행 불가능한 선언을 기동 시점에 거부.** `@Query`의 스칼라/집계/DTO 반환, 비-suspend(`Flow` 포함) 쿼리 메서드, 이름과 인자 개수가 같은 오버로드, 메서드명이 요구하는 파라미터 수와 선언이 다른 경우, `Top`/`First` + `Pageable` 조합이 해당됩니다.

### 삭제 의미론

`deleteById`, `delete`, `deleteAll`, `deleteAllById`와 파생 `deleteBy…`가 bulk `DELETE` 문 대신 대상을 로드한 뒤 제거합니다. cascade, `@Version` 낙관적 락, `@PreRemove` 콜백이 정상 동작하고 영속성 컨텍스트도 일관되게 유지됩니다(`SimpleJpaRepository`와 동일). 파생 삭제는 `Unit`·`Int`·`Long`으로 삭제 건수를 반환할 수 있습니다.

`DELETE` 전에 `SELECT`가 한 번 실행되는 비용이 있습니다. cascade가 필요 없는 대량 삭제는 `@Modifying @Query("DELETE …")`를 쓰도록 문서화했습니다.

### 트랜잭션

- **`@Transactional` + `tx.transactional` 혼용.** `tx.transactional`이 Spring 트랜잭션을 감지하지 못해, 쓰이지도 않는 두 번째 세션과 트랜잭션을 열고 있었습니다. 코어 모듈은 Spring에 의존하지 않으므로 pluggable probe(`AmbientTransactionProbe`)를 두고 스타터가 구현을 제공합니다. `readOnly` 트랜잭션의 쓰기 승격도 거부합니다.
- **트랜잭션 매니저 back-off.** `@ConditionalOnMissingBean`이 구현 클래스만 매칭해서, R2DBC와 공존하면 첫 `@Transactional` 호출 시점(기동 시점이 아니라)에 `NoUniqueBeanDefinitionException`이 발생했습니다.
- **`runOnVertxContext` 무한 대기.** 블록이 동기적으로 던지면 sink가 종료되지 않아 커밋/롤백이 영원히 대기했습니다. 세션에서 `ReactiveConnection`을 꺼내는 리플렉션이 대표적인 동기 실패 지점입니다.

### 설정

- **필수 `@Value` 제거.** `spring.datasource.url` 등 4개가 기본값 없이 생성자 주입되어, 자체 `Mutiny.SessionFactory`를 정의했거나 비밀번호 없는 DB를 쓰는 앱도 `Could not resolve placeholder`로 기동에 실패했습니다. 이제 선택값이며 실패 시 조치 방법이 담긴 메시지를 냅니다.
- **`spring.jpa.properties.*` 전체 통과.** 하드코딩된 allowlist(~22개) 때문에 `hibernate.default_schema` 같은 흔한 설정이 조용히 무시됐습니다.
- **영속성 유닛 스캔 확장.** `@Entity`만 등록해서 `@Converter(autoApply = true)`가 누락되고 잘못된 컬럼 매핑이 경고 없이 기록될 수 있었습니다. `@Embeddable`·`@MappedSuperclass`·`@Converter`를 앱 클래스로더로 함께 등록합니다.
- **`@EnableHibernateReactiveRepositories` 패키지 병합.** 여러 모듈이 각자 선언하면 마지막 것만 적용되어 앞선 모듈의 Repository가 등록되지 않았습니다.
- **Auditing.** `OffsetDateTime`(`timestamptz`의 표준 매핑) 지원, 미지원 타입에 경고 로그, 생성 시 `createdAt`/`updatedAt`을 같은 시각으로 기록, JPMS `InaccessibleObjectException` 처리.

### 그 외

- Boot 4의 `@EnableTransactionManagement`가 사용자 선언과 경합하지 않도록 back-off 조건 추가
- `ReactiveAuditorAware`가 둘 이상일 때 명확한 메시지로 실패
- 동작하지 않던 `annotationProcessor` 선언 제거 (메타데이터는 수기 관리 중)
- 무제한 대기 큐로 인한 브라운아웃 위험을 풀 프로퍼티 KDoc에 명시

## 테스트

전체 **964개 통과** (starter 479, boot4 454, core 31). ABI 검증과 발행 메타데이터 검증도 통과합니다.

기능별로 회귀 테스트를 추가했고, 실제 PostgreSQL에 대한 통합 테스트로 cascade 삭제·`Top`/`First` 제한·LIKE 이스케이프·엔티티 이름 해석·`@Query` 정렬을 검증했습니다. 트랜잭션 모델 수정은 probe를 일시적으로 해제해 테스트가 실제로 실패하는지 확인한 뒤 원복했습니다.

작업 중 **테스트 픽스처의 잠재 버그**도 발견해 고쳤습니다. `IntegrationTestBase.clearAllTables`가 Uni를 체이닝하지 않아 마지막 `DELETE` 하나만 실제로 실행되고 있었고, 그래서 `ChildEntity`/`ParentEntity` 등의 테스트 간 격리가 계속 동작하지 않던 상태였습니다.

## 호환성

`ReactiveTransactionExecutor`의 기존 단일 인자 생성자는 `@JvmOverloads`로 보존해 바이너리 호환성을 유지했습니다.

동작이 바뀌는 부분(삭제 의미론, LIKE 이스케이프, 기동 시점 거부 등)은 `docs/migration.md`와 `docs/migration.ko.md`의 "동작 상 주의점" 절에 정리했습니다. Hibernate ORM 7 제약이 소비자에게 전파되는 문제는 hibernate-reactive 3.1이 실제로 ORM 7을 요구하므로 스코프를 바꾸는 대신, Boot 3에서 `spring-boot-starter-data-jpa`와 함께 쓰면 안 된다는 점을 README에 명시했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
