### PR TITLE
chore: bump documented version to 1.1.0

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -37,10 +37,10 @@ Hibernate Reactive + Kotlin Coroutines 환경에서 Spring Data JPA의 편의성
 ```kotlin
 dependencies {
     // Spring Boot 3.x
-    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0")
+    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.1.0")
 
     // Spring Boot 4.x
-    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.0.0")
+    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.1.0")
 
     // DB 드라이버
     implementation("io.vertx:vertx-pg-client:4.5.16")
@@ -52,10 +52,10 @@ dependencies {
 ```groovy
 dependencies {
     // Spring Boot 3.x
-    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0'
+    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.1.0'
 
     // Spring Boot 4.x
-    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.0.0'
+    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.1.0'
 
     // DB 드라이버
     implementation 'io.vertx:vertx-pg-client:4.5.16'
@@ -69,14 +69,14 @@ dependencies {
 <dependency>
     <groupId>io.clroot</groupId>
     <artifactId>hibernate-reactive-coroutines-spring-boot-starter</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 
 <!-- Spring Boot 4.x -->
 <dependency>
     <groupId>io.clroot</groupId>
     <artifactId>hibernate-reactive-coroutines-spring-boot-starter-boot4</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ This library provides a **Spring Boot starter for Hibernate Reactive** with firs
 ```kotlin
 dependencies {
     // For Spring Boot 3.x
-    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0")
+    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.1.0")
 
     // For Spring Boot 4.x
-    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.0.0")
+    implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.1.0")
 
     // Database driver (choose one)
     implementation("io.vertx:vertx-pg-client:4.5.16")      // PostgreSQL
@@ -67,10 +67,10 @@ dependencies {
 ```groovy
 dependencies {
     // For Spring Boot 3.x
-    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0'
+    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.1.0'
 
     // For Spring Boot 4.x
-    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.0.0'
+    implementation 'io.clroot:hibernate-reactive-coroutines-spring-boot-starter-boot4:1.1.0'
 
     // Database driver
     implementation 'io.vertx:vertx-pg-client:4.5.16'
@@ -84,14 +84,14 @@ dependencies {
 <dependency>
     <groupId>io.clroot</groupId>
     <artifactId>hibernate-reactive-coroutines-spring-boot-starter</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 
 <!-- For Spring Boot 4.x -->
 <dependency>
     <groupId>io.clroot</groupId>
     <artifactId>hibernate-reactive-coroutines-spring-boot-starter-boot4</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/docs/migration.ko.md
+++ b/docs/migration.ko.md
@@ -111,7 +111,7 @@ Spring 트랜잭션이 있으면 새 세션을 열지 않고 그 트랜잭션에
 implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
 // 추가
-implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0")
+implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.1.0")
 implementation("io.vertx:vertx-pg-client:4.5.16")  // 또는 MySQL
 ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -111,7 +111,7 @@ Spring transaction instead of opening a second session, and refuses to upgrade a
 implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
 // Add
-implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.0.0")
+implementation("io.clroot:hibernate-reactive-coroutines-spring-boot-starter:1.1.0")
 implementation("io.vertx:vertx-pg-client:4.5.16")  // or MySQL
 ```
 


### PR DESCRIPTION
설치 안내에 적힌 버전을 1.1.0 릴리스에 맞춰 갱신합니다.

README(한/영)의 Gradle·Maven 스니펫과 마이그레이션 가이드의 의존성 예시가 대상입니다. 코드 변경은 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)